### PR TITLE
Fix uncommented redis config in env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,7 +31,7 @@ SESSION_DRIVER=file
 SESSION_LIFETIME=120
 SESSION_ENCRYPT=false
 
-CACHE_STORE=redis
+CACHE_STORE=file
 QUEUE_CONNECTION=database
 
 # Redis Configuration (for production caching)


### PR DESCRIPTION
Change `CACHE_STORE` in `.env.example` from `redis` to `file` to prevent cache connection failures for new setups.

---

[Open in Web](https://cursor.com/agents?id=bc-44094c2b-40d0-4df7-ac9a-94c8b31ca4ef) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-44094c2b-40d0-4df7-ac9a-94c8b31ca4ef) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)