### PR TITLE
[DEL-251] Mention optional deuterocanonical support on the landing page

### DIFF
--- a/resources/views/landing.blade.php
+++ b/resources/views/landing.blade.php
@@ -92,6 +92,7 @@
                 "Daily Streak Tracking",
                 "Daily Reading Log",
                 "Book Completion Grid",
+                "Optional Catholic 73-Book Support",
                 "Reading Statistics",
                 "Weekly Journey"
             ]
@@ -422,8 +423,7 @@
                                 </div>
 
                                 <p class="text-gray-600 leading-relaxed">
-                                    Visualize your Scripture journey with a beautiful grid of all 66 Bible books. Watch
-                                    your progress unfold as you complete each book.
+                                    Visualize your Scripture journey across the 66-book canon by default, with optional Catholic 73-book deuterocanonical support available when enabled in Settings.
                                 </p>
                             </x-ui.card-content>
                         </x-ui.card>

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -3,5 +3,13 @@
 test('the application returns a successful response', function () {
     $response = $this->get('/');
 
-    $response->assertStatus(200);
+    $response->assertSuccessful()
+        ->assertSeeText('66-book canon by default')
+        ->assertSeeText('optional Catholic 73-book deuterocanonical support')
+        ->assertSeeTextInOrder([
+            'Keep Every Bible Reading Visible, Stay on Track',
+            'Everything You Need to Stay Consistent',
+            'Book Completion Grid',
+            'optional Catholic 73-book deuterocanonical support',
+        ]);
 });


### PR DESCRIPTION
## Summary
- Adds a subtle mention of optional Catholic 73-book deuterocanonical support in the landing page features section.
- Keeps the hero focused on the core reading-tracking value proposition and leaves the 66-book experience as the default.
- Updates the existing root-page smoke test to cover the new landing-page copy instead of adding a separate test file.

## Testing
- `php artisan test --compact tests/Feature/ExampleTest.php`
- `vendor/bin/pint --dirty --format agent`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Optional Catholic 73-Book Support to landing page features.
  * Updated Book Completion Grid feature to highlight support for both 66-book canon and optional 73-book deuterocanonical editions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->