### PR TITLE
[DEL-252] Improve announcement SEO discovery and indexing

### DIFF
--- a/app/Http/Controllers/SitemapController.php
+++ b/app/Http/Controllers/SitemapController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Announcement;
 use Illuminate\Http\Response;
 
 class SitemapController extends Controller
@@ -34,8 +35,16 @@ class SitemapController extends Controller
         $sitemap .= '<priority>0.3</priority>';
         $sitemap .= '</url>';
 
+        // Updates index
+        $sitemap .= '<url>';
+        $sitemap .= '<loc>'.route('announcements.index').'</loc>';
+        $sitemap .= '<lastmod>'.now()->toISOString().'</lastmod>';
+        $sitemap .= '<changefreq>weekly</changefreq>';
+        $sitemap .= '<priority>0.7</priority>';
+        $sitemap .= '</url>';
+
         // Announcements
-        $announcements = \App\Models\Announcement::active()->get();
+        $announcements = Announcement::active()->get();
         foreach ($announcements as $announcement) {
             $sitemap .= '<url>';
             $sitemap .= '<loc>'.route('announcements.show', $announcement->slug).'</loc>';

--- a/app/Http/Controllers/SitemapController.php
+++ b/app/Http/Controllers/SitemapController.php
@@ -15,7 +15,7 @@ class SitemapController extends Controller
         // Landing page
         $sitemap .= '<url>';
         $sitemap .= '<loc>'.config('app.url').'</loc>';
-        $sitemap .= '<lastmod>'.now()->toISOString().'</lastmod>';
+        $sitemap .= '<lastmod>'.now()->toIso8601String().'</lastmod>';
         $sitemap .= '<changefreq>weekly</changefreq>';
         $sitemap .= '<priority>1.0</priority>';
         $sitemap .= '</url>';
@@ -23,28 +23,30 @@ class SitemapController extends Controller
         // Legal pages
         $sitemap .= '<url>';
         $sitemap .= '<loc>'.config('app.url').'/privacy-policy</loc>';
-        $sitemap .= '<lastmod>'.now()->toISOString().'</lastmod>';
+        $sitemap .= '<lastmod>'.now()->toIso8601String().'</lastmod>';
         $sitemap .= '<changefreq>monthly</changefreq>';
         $sitemap .= '<priority>0.3</priority>';
         $sitemap .= '</url>';
 
         $sitemap .= '<url>';
         $sitemap .= '<loc>'.config('app.url').'/terms-of-service</loc>';
-        $sitemap .= '<lastmod>'.now()->toISOString().'</lastmod>';
+        $sitemap .= '<lastmod>'.now()->toIso8601String().'</lastmod>';
         $sitemap .= '<changefreq>monthly</changefreq>';
         $sitemap .= '<priority>0.3</priority>';
         $sitemap .= '</url>';
 
+        $announcements = Announcement::active()->latest('updated_at')->get();
+        $updatesLastModified = $announcements->first()?->updated_at ?? now();
+
         // Updates index
         $sitemap .= '<url>';
         $sitemap .= '<loc>'.route('announcements.index').'</loc>';
-        $sitemap .= '<lastmod>'.now()->toISOString().'</lastmod>';
+        $sitemap .= '<lastmod>'.$updatesLastModified->toIso8601String().'</lastmod>';
         $sitemap .= '<changefreq>weekly</changefreq>';
         $sitemap .= '<priority>0.7</priority>';
         $sitemap .= '</url>';
 
         // Announcements
-        $announcements = Announcement::active()->get();
         foreach ($announcements as $announcement) {
             $sitemap .= '<url>';
             $sitemap .= '<loc>'.route('announcements.show', $announcement->slug).'</loc>';

--- a/app/Models/Announcement.php
+++ b/app/Models/Announcement.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model; // Added this line based on 'use HasFactory;'
+use Illuminate\Support\Str;
 
 class Announcement extends Model
 {
@@ -75,6 +76,29 @@ class Announcement extends Model
         }
 
         return $this->heroImageUrl();
+    }
+
+    public function seoDescription(int $limit = 160): string
+    {
+        $paragraphs = preg_split('/\R{2,}/', trim($this->content)) ?: [];
+
+        foreach ($paragraphs as $paragraph) {
+            $paragraph = trim($paragraph);
+
+            if ($paragraph === '' || str_starts_with($paragraph, '#')) {
+                continue;
+            }
+
+            $description = trim(preg_replace('/\s+/', ' ', strip_tags((string) Str::markdown($paragraph))) ?? '');
+
+            if ($description !== '') {
+                return Str::limit($description, $limit);
+            }
+        }
+
+        $description = trim(preg_replace('/\s+/', ' ', strip_tags((string) Str::markdown($this->content))) ?? '');
+
+        return Str::limit($description, $limit);
     }
 
     /**

--- a/app/Models/Announcement.php
+++ b/app/Models/Announcement.php
@@ -80,25 +80,27 @@ class Announcement extends Model
 
     public function seoDescription(int $limit = 160): string
     {
-        $paragraphs = preg_split('/\R{2,}/', trim($this->content)) ?: [];
+        $plainText = once(function (): string {
+            $paragraphs = preg_split('/\R{2,}/', trim($this->content)) ?: [];
 
-        foreach ($paragraphs as $paragraph) {
-            $paragraph = trim($paragraph);
+            foreach ($paragraphs as $paragraph) {
+                $paragraph = trim($paragraph);
 
-            if ($paragraph === '' || str_starts_with($paragraph, '#')) {
-                continue;
+                if ($paragraph === '' || str_starts_with($paragraph, '#')) {
+                    continue;
+                }
+
+                $description = trim(preg_replace('/\s+/', ' ', strip_tags((string) Str::markdown($paragraph))) ?? '');
+
+                if ($description !== '') {
+                    return $description;
+                }
             }
 
-            $description = trim(preg_replace('/\s+/', ' ', strip_tags((string) Str::markdown($paragraph))) ?? '');
+            return trim(preg_replace('/\s+/', ' ', strip_tags((string) Str::markdown($this->content))) ?? '');
+        });
 
-            if ($description !== '') {
-                return Str::limit($description, $limit);
-            }
-        }
-
-        $description = trim(preg_replace('/\s+/', ' ', strip_tags((string) Str::markdown($this->content))) ?? '');
-
-        return Str::limit($description, $limit);
+        return Str::limit($plainText, $limit);
     }
 
     /**

--- a/database/seeders/ReleaseAnnouncementsSeeder.php
+++ b/database/seeders/ReleaseAnnouncementsSeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 use App\Models\Announcement;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Carbon;
 
 class ReleaseAnnouncementsSeeder extends Seeder
 {
@@ -57,7 +58,7 @@ MD;
                 'type' => 'info',
                 'hero_image_path' => 'images/deuterocanonical-books-hero.jpg',
                 'social_image_path' => 'images/deuterocanonical-books-social.jpg',
-                'starts_at' => now(),
+                'starts_at' => Carbon::create(2026, 4, 30, 12, 0, 0),
                 'ends_at' => null,
             ]
         );

--- a/resources/views/announcements/index.blade.php
+++ b/resources/views/announcements/index.blade.php
@@ -3,6 +3,8 @@
 @section('title', 'Product Updates - Delight')
 @section('meta')
     <meta name="description" content="Latest news, updates, and feature releases from Delight.">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="{{ route('announcements.index') }}">
 
     <!-- Social -->
     <meta property="og:image" content="{{ asset('images/social-updates.png') }}">
@@ -47,7 +49,7 @@
                             </a>
                         </h3>
                         <p class="mt-3 line-clamp-3 text-sm leading-6 text-gray-600 dark:text-gray-400">
-                            {{ Str::limit(strip_tags(Str::markdown($announcement->content)), 200) }}
+                            {{ $announcement->seoDescription(200) }}
                         </p>
                     </div>
                 </article>

--- a/resources/views/announcements/show.blade.php
+++ b/resources/views/announcements/show.blade.php
@@ -5,9 +5,12 @@
 @section('meta')
     @php($heroImageUrl = $announcement->heroImageUrl())
     @php($socialImageUrl = $announcement->socialImageUrl())
-    <meta name="description" content="{{ Str::limit(strip_tags(Str::markdown($announcement->content)), 150) }}">
+    @php($seoDescription = $announcement->seoDescription(150))
+    <meta name="description" content="{{ $seoDescription }}">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="{{ route('announcements.show', $announcement->slug) }}">
     <meta property="og:title" content="{{ $announcement->title }}">
-    <meta property="og:description" content="{{ Str::limit(strip_tags(Str::markdown($announcement->content)), 200) }}">
+    <meta property="og:description" content="{{ $announcement->seoDescription(200) }}">
     <meta property="og:type" content="article">
     <meta property="og:url" content="{{ route('announcements.show', $announcement->slug) }}">
     <meta property="article:published_time" content="{{ $announcement->starts_at->toIso8601String() }}">
@@ -40,7 +43,7 @@
                                  "url": "{{ asset('images/logo-64.png') }}"
                             }
                         },
-                        "description": "{{ Str::limit(strip_tags(Str::markdown($announcement->content)), 150) }}"
+                        "description": {{ Js::from($seoDescription) }}
                     }
                     </script>
 @endsection

--- a/resources/views/announcements/show.blade.php
+++ b/resources/views/announcements/show.blade.php
@@ -43,7 +43,7 @@
                                  "url": "{{ asset('images/logo-64.png') }}"
                             }
                         },
-                        "description": {{ Js::from($seoDescription) }}
+                        "description": {!! json_encode($seoDescription, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) !!}
                     }
                     </script>
 @endsection

--- a/resources/views/landing.blade.php
+++ b/resources/views/landing.blade.php
@@ -645,6 +645,9 @@
                         <li><a href="{{ route('login') }}"
                                 class="text-gray-300 hover:text-white transition-colors focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-900 rounded-sm">Sign
                                 In</a></li>
+                        <li><a href="{{ route('announcements.index') }}"
+                                class="text-gray-300 hover:text-white transition-colors focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-900 rounded-sm">Updates</a>
+                        </li>
                     </ul>
                 </nav>
 

--- a/tests/Feature/AnnouncementSeederTest.php
+++ b/tests/Feature/AnnouncementSeederTest.php
@@ -13,6 +13,7 @@ it('seeds the deuterocanonical books release announcement', function () {
         ->and($announcement->type)->toBe('info')
         ->and($announcement->hero_image_path)->toBe('images/deuterocanonical-books-hero.jpg')
         ->and($announcement->social_image_path)->toBe('images/deuterocanonical-books-social.jpg')
+        ->and($announcement->starts_at->toDateTimeString())->toBe('2026-04-30 12:00:00')
         ->and($announcement->ends_at)->toBeNull()
         ->and($announcement->content)->toContain('## What changed')
         ->and($announcement->content)->not->toContain('### Deuterocanonical books are now available')

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -4,6 +4,7 @@ test('the application returns a successful response', function () {
     $response = $this->get('/');
 
     $response->assertSuccessful()
+        ->assertSee('href="'.route('announcements.index').'"', false)
         ->assertSeeText('66-book canon by default')
         ->assertSeeText('optional Catholic 73-book deuterocanonical support')
         ->assertSeeTextInOrder([

--- a/tests/Feature/PublicAnnouncementSeoTest.php
+++ b/tests/Feature/PublicAnnouncementSeoTest.php
@@ -32,4 +32,10 @@ it('renders announcement article seo directives and a body-first description for
         ->assertSee('<meta name="description" content="You can now enable the Catholic 73-book canon from Settings.', false)
         ->assertSee('property="og:description" content="You can now enable the Catholic 73-book canon from Settings.', false)
         ->assertDontSee('<meta name="description" content="What changed', false);
+
+    preg_match('/<script type="application\/ld\+json">\s*(.*?)\s*<\/script>/s', $response->getContent(), $matches);
+
+    expect($matches[1] ?? null)->not->toBeNull();
+    expect(json_decode($matches[1], associative: true, flags: JSON_THROW_ON_ERROR))
+        ->description->toStartWith('You can now enable the Catholic 73-book canon from Settings.');
 });

--- a/tests/Feature/PublicAnnouncementSeoTest.php
+++ b/tests/Feature/PublicAnnouncementSeoTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use App\Models\Announcement;
+use Database\Seeders\ReleaseAnnouncementsSeeder;
+
+it('renders announcement index seo directives for guests', function () {
+    Announcement::create([
+        'title' => 'Visible Update',
+        'slug' => 'visible-update',
+        'content' => "## What changed\n\nA visible public update.",
+        'type' => 'info',
+        'starts_at' => now()->subDay(),
+    ]);
+
+    $response = $this->get(route('announcements.index'));
+
+    $response->assertOk()
+        ->assertSee('<link rel="canonical" href="'.route('announcements.index').'">', false)
+        ->assertSee('<meta name="robots" content="index, follow">', false);
+});
+
+it('renders announcement article seo directives and a body-first description for guests', function () {
+    $this->seed(ReleaseAnnouncementsSeeder::class);
+
+    $announcement = Announcement::where('slug', 'deuterocanonical-books-release')->firstOrFail();
+
+    $response = $this->get(route('announcements.show', $announcement->slug));
+
+    $response->assertOk()
+        ->assertSee('<link rel="canonical" href="'.route('announcements.show', $announcement->slug).'">', false)
+        ->assertSee('<meta name="robots" content="index, follow">', false)
+        ->assertSee('<meta name="description" content="You can now enable the Catholic 73-book canon from Settings.', false)
+        ->assertSee('property="og:description" content="You can now enable the Catholic 73-book canon from Settings.', false)
+        ->assertDontSee('<meta name="description" content="What changed', false);
+});

--- a/tests/Feature/SitemapTest.php
+++ b/tests/Feature/SitemapTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\Announcement;
+use Illuminate\Support\Carbon;
 
 it('lists the updates index and visible announcement articles', function () {
     $visibleAnnouncement = Announcement::create([
@@ -35,4 +36,36 @@ it('lists the updates index and visible announcement articles', function () {
         ->assertSee('<loc>'.route('announcements.show', $visibleAnnouncement->slug).'</loc>', false)
         ->assertDontSee(route('announcements.show', $futureAnnouncement->slug), false)
         ->assertDontSee(route('announcements.show', $expiredAnnouncement->slug), false);
+});
+
+it('uses the most recently updated visible announcement for the updates index lastmod', function () {
+    Carbon::setTestNow(Carbon::create(2026, 5, 6, 12, 0, 0));
+
+    $olderAnnouncement = Announcement::create([
+        'title' => 'Older Update',
+        'slug' => 'older-update',
+        'content' => 'Older article body.',
+        'type' => 'info',
+        'starts_at' => now()->subDays(10),
+    ]);
+
+    $newerAnnouncement = Announcement::create([
+        'title' => 'Newer Update',
+        'slug' => 'newer-update',
+        'content' => 'Newer article body.',
+        'type' => 'info',
+        'starts_at' => now()->subDays(5),
+    ]);
+
+    Announcement::withoutTimestamps(function () use ($olderAnnouncement, $newerAnnouncement) {
+        $olderAnnouncement->forceFill(['updated_at' => Carbon::create(2026, 4, 20, 8, 0, 0)])->save();
+        $newerAnnouncement->forceFill(['updated_at' => Carbon::create(2026, 4, 30, 9, 30, 0)])->save();
+    });
+
+    $response = $this->get(route('sitemap'));
+
+    $expectedUpdatesEntry = '<url><loc>'.route('announcements.index').'</loc><lastmod>'.$newerAnnouncement->fresh()->updated_at->toIso8601String().'</lastmod>';
+
+    $response->assertOk()
+        ->assertSee($expectedUpdatesEntry, false);
 });

--- a/tests/Feature/SitemapTest.php
+++ b/tests/Feature/SitemapTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Models\Announcement;
+
+it('lists the updates index and visible announcement articles', function () {
+    $visibleAnnouncement = Announcement::create([
+        'title' => 'Visible Update',
+        'slug' => 'visible-update',
+        'content' => 'Visible article body.',
+        'type' => 'info',
+        'starts_at' => now()->subDay(),
+    ]);
+
+    $futureAnnouncement = Announcement::create([
+        'title' => 'Future Update',
+        'slug' => 'future-update',
+        'content' => 'Future article body.',
+        'type' => 'info',
+        'starts_at' => now()->addDay(),
+    ]);
+
+    $expiredAnnouncement = Announcement::create([
+        'title' => 'Expired Update',
+        'slug' => 'expired-update',
+        'content' => 'Expired article body.',
+        'type' => 'info',
+        'starts_at' => now()->subDays(2),
+        'ends_at' => now()->subDay(),
+    ]);
+
+    $response = $this->get(route('sitemap'));
+
+    $response->assertOk()
+        ->assertSee('<loc>'.route('announcements.index').'</loc>', false)
+        ->assertSee('<loc>'.route('announcements.show', $visibleAnnouncement->slug).'</loc>', false)
+        ->assertDontSee(route('announcements.show', $futureAnnouncement->slug), false)
+        ->assertDontSee(route('announcements.show', $expiredAnnouncement->slug), false);
+});


### PR DESCRIPTION
## Summary
- Add a crawlable homepage footer link to `/updates`.
- Include the updates index in the sitemap alongside visible announcement articles.
- Add canonical URLs and `index, follow` robots meta to announcement index/show pages.
- Generate cleaner body-first announcement excerpts for meta descriptions and JSON-LD.
- Pin the seeded deuterocanonical release timestamp so reseeds stay stable.

## Testing
- Added feature coverage for homepage linking, sitemap contents, announcement SEO tags, and seeded publish-time stability.
- Ran the focused announcement tests plus the full Laravel test suite.
- `pint` formatting passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Updates" footer link to access announcements.
  * Announcements index now appears in the sitemap with an updates entry reflecting recent changes.

* **Improvements**
  * Consistent, improved SEO descriptions for announcement listings and pages; enhanced meta tags (description, robots, canonical) and structured data.

* **Tests**
  * New/updated feature tests covering SEO tags, sitemap entries, and seeded announcement timestamps.

* **Chores**
  * Seed data timestamp made explicit for predictable test behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->