### PR TITLE
[DEL-257] Fix PWA manifest screenshot references

### DIFF
--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -37,15 +37,15 @@
   ],
   "screenshots": [
     {
-      "src": "/images/screenshots/mobile_v2.png",
-      "sizes": "432x934",
+      "src": "/images/screenshots/mobile-v3.png",
+      "sizes": "726x1570",
       "type": "image/png",
       "form_factor": "narrow",
       "label": "Dashboard view on mobile"
     },
     {
-      "src": "/images/screenshots/desktop_v2.1.png",
-      "sizes": "4112x2580",
+      "src": "/images/screenshots/desktop-v3.png",
+      "sizes": "3456x1924",
       "type": "image/png",
       "form_factor": "wide",
       "label": "Dashboard view on desktop"

--- a/tests/Feature/PwaManifestTest.php
+++ b/tests/Feature/PwaManifestTest.php
@@ -14,8 +14,10 @@ test('manifest screenshots reference existing assets with accurate dimensions', 
 
         expect($path)->toBeFile();
 
-        [$width, $height] = getimagesize($path);
+        $image = getimagesize($path);
 
-        expect($screenshot['sizes'])->toBe($width.'x'.$height);
+        expect($image)->not->toBeFalse()
+            ->and($image['mime'])->toBe($screenshot['type'])
+            ->and($screenshot['sizes'])->toBe($image[0].'x'.$image[1]);
     }
 });

--- a/tests/Feature/PwaManifestTest.php
+++ b/tests/Feature/PwaManifestTest.php
@@ -1,0 +1,21 @@
+<?php
+
+test('manifest screenshots reference existing assets with accurate dimensions', function () {
+    $manifest = json_decode(file_get_contents(public_path('site.webmanifest')), true, flags: JSON_THROW_ON_ERROR);
+
+    expect($manifest['screenshots'])->toHaveCount(2);
+    expect(array_column($manifest['screenshots'], 'src'))->toBe([
+        '/images/screenshots/mobile-v3.png',
+        '/images/screenshots/desktop-v3.png',
+    ]);
+
+    foreach ($manifest['screenshots'] as $screenshot) {
+        $path = public_path(ltrim($screenshot['src'], '/'));
+
+        expect($path)->toBeFile();
+
+        [$width, $height] = getimagesize($path);
+
+        expect($screenshot['sizes'])->toBe($width.'x'.$height);
+    }
+});


### PR DESCRIPTION
## Summary
- Updated `public/site.webmanifest` to point at the current screenshot assets.
- Corrected the manifest screenshot dimensions to match the actual PNG files.
- Added focused feature coverage to verify the manifest references existing assets and that the declared sizes match the image metadata.

## Testing
- `php artisan test --compact tests/Feature/PwaManifestTest.php`
- `vendor/bin/pint --dirty --format agent`
- Verified the referenced local screenshot URLs return `200`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Progressive Web App screenshot assets for mobile and desktop installation displays.

* **Tests**
  * Added validation tests for screenshot asset references and image dimensions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Orlando-Villanueva/delight/pull/129?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->