### PR TITLE
[DEL-259] Add iOS safe-area spacing to mobile bottom navigation

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -261,6 +261,29 @@ html {
         z-index: 60;
     }
 
+    .px-mobile-safe {
+        padding-left: calc(1rem + env(safe-area-inset-left, 0px));
+        padding-right: calc(1rem + env(safe-area-inset-right, 0px));
+    }
+
+    .pt-mobile-safe {
+        padding-top: calc(0.75rem + env(safe-area-inset-top, 0px));
+    }
+
+    .bottom-mobile-nav-safe {
+        bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
+    }
+
+    .pb-mobile-nav-safe {
+        padding-bottom: calc(6rem + env(safe-area-inset-bottom, 0px));
+    }
+
+    @media (width >= 64rem) {
+        .pb-mobile-nav-safe {
+            padding-bottom: 1rem;
+        }
+    }
+
     .z-stack-backdrop {
         z-index: 70;
     }

--- a/resources/views/components/navigation/mobile-bottom-bar.blade.php
+++ b/resources/views/components/navigation/mobile-bottom-bar.blade.php
@@ -2,7 +2,7 @@
 {{-- Uniform icon navigation with accent-colored Log button --}}
 
 <div id="mobile-bottom-navigation"
-    class="fixed z-50 w-full h-16 max-w-lg -translate-x-1/2 bg-white/80 backdrop-blur-md border border-gray-200 rounded-full bottom-4 left-1/2 dark:bg-gray-800/80 dark:border-gray-700 shadow-xl lg:hidden">
+    class="fixed z-stack-nav w-full h-16 max-w-lg -translate-x-1/2 bg-white/80 backdrop-blur-md border border-gray-200 rounded-full bottom-mobile-nav-safe left-1/2 dark:bg-gray-800/80 dark:border-gray-700 shadow-xl lg:hidden">
     <div class="grid h-full max-w-lg grid-cols-5 mx-auto">
         {{-- Dashboard --}}
         <x-navigation.nav-link route="dashboard" label="Dashboard" variant="mobile" class="rounded-s-full">

--- a/resources/views/components/navigation/mobile-navbar.blade.php
+++ b/resources/views/components/navigation/mobile-navbar.blade.php
@@ -2,7 +2,7 @@
 {{-- Flowbite-based navbar that scrolls with content (not fixed) --}}
 
 <nav class="lg:hidden bg-white border-b border-gray-200 dark:bg-gray-800 dark:border-gray-700">
-    <div class="px-4 py-3">
+    <div class="px-mobile-safe pt-mobile-safe pb-3">
         <div class="flex items-center justify-between">
             <div class="flex items-center space-x-2">
                 <div class="w-8 h-8 rounded-lg flex items-center justify-center">

--- a/resources/views/layouts/authenticated.blade.php
+++ b/resources/views/layouts/authenticated.blade.php
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="csrf-token" content="{{ csrf_token() }}">
 
     @php($appName = config('app.name', 'Delight'))
@@ -69,10 +69,10 @@
             <main class="flex-1 lg:overflow-y-auto">
                 {{-- Standardized page container with:
                      - Standard horizontal and top padding
-                     - Vertical clearance for mobile bottom navigation (pb-24)
+                     - Vertical clearance for mobile bottom navigation and iOS safe areas
                 --}}
                 <div id="page-container"
-                    class="container mx-auto px-4 pt-4 pb-24 md:pb-4 lg:min-h-full lg:flex lg:flex-col">
+                    class="container mx-auto px-mobile-safe pt-4 pb-mobile-nav-safe lg:pb-4 lg:min-h-full lg:flex lg:flex-col">
                     @yield('content')
                 </div>
             </main>

--- a/tests/Feature/NavigationTest.php
+++ b/tests/Feature/NavigationTest.php
@@ -44,6 +44,23 @@ describe('Navigation Component Rendering', function () {
         // Check for sr-only labels in mobile navigation
         $response->assertSee('Dashboard', false);
         $response->assertSee('History', false);
+        $response->assertSee('content="width=device-width, initial-scale=1, viewport-fit=cover"', false);
+        $response->assertSee('px-mobile-safe pt-mobile-safe pb-3', false);
+        $response->assertSee('z-stack-nav', false);
+        $response->assertSee('bottom-mobile-nav-safe', false);
+        $response->assertSee('pb-mobile-nav-safe lg:pb-4', false);
+    });
+
+    it('defines safe area utilities for mobile navigation spacing', function () {
+        $css = file_get_contents(resource_path('css/app.css'));
+
+        expect($css)
+            ->toContain('.bottom-mobile-nav-safe')
+            ->toContain('bottom: calc(1rem + env(safe-area-inset-bottom, 0px));')
+            ->toContain('.pb-mobile-nav-safe')
+            ->toContain('padding-bottom: calc(6rem + env(safe-area-inset-bottom, 0px));')
+            ->toContain('@media (width >= 64rem)')
+            ->toContain('padding-bottom: 1rem;');
     });
 
     it('centers the log reading action in the mobile bottom navigation order', function () {
@@ -422,7 +439,7 @@ describe('Navigation Component Integration', function () {
         // Check that key navigation elements from all components are present
         $response->assertSee('<nav', false); // Desktop navbar
         $response->assertSee('<aside', false); // Desktop sidebar
-        $response->assertSee('rounded-full bottom-4', false); // Mobile bottom bar
+        $response->assertSee('rounded-full bottom-mobile-nav-safe', false); // Mobile bottom bar
     });
 
     it('includes browser navigation support script', function () {


### PR DESCRIPTION
## Summary
- Added safe-area-aware spacing for the fixed mobile bottom navigation so iPhone home-indicator layouts get extra clearance
- Applied matching bottom padding to authenticated page content while preserving the existing desktop spacing
- Opted the authenticated layout into `viewport-fit=cover` so `env(safe-area-inset-bottom)` can resolve on iOS
- Added focused navigation coverage for the rendered classes and CSS utilities

## Testing
- `php artisan test --compact tests/Feature/NavigationTest.php`
- `vendor/bin/pint --dirty --format agent`
- Browser-verified the dashboard layout at a mobile viewport and confirmed the viewport meta and computed spacing