### PR TITLE
[DEL-260] Add global HTMX navigation loading feedback

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -69,6 +69,34 @@ html {
     scroll-behavior: smooth;
 }
 
+.page-navigation-loading {
+    appearance: none;
+    border: 0;
+    background-color: transparent;
+}
+
+.page-navigation-loading::-webkit-progress-bar {
+    background-color: transparent;
+}
+
+.page-navigation-loading::-webkit-progress-value {
+    animation: page-navigation-loading-pulse 1.5s ease-in-out infinite;
+    background-color: var(--color-primary-500);
+    box-shadow: 0 0 12px rgba(51, 102, 204, 0.45);
+}
+
+.page-navigation-loading::-moz-progress-bar {
+    animation: page-navigation-loading-pulse 1.5s ease-in-out infinite;
+    background-color: var(--color-primary-500);
+    box-shadow: 0 0 12px rgba(51, 102, 204, 0.45);
+}
+
+@keyframes page-navigation-loading-pulse {
+    50% {
+        opacity: 0.5;
+    }
+}
+
 /* Scrollbar theming for light/dark modes */
 :root {
     --scrollbar-track: transparent;

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -80,21 +80,15 @@ html {
 }
 
 .page-navigation-loading::-webkit-progress-value {
-    animation: page-navigation-loading-pulse 1.5s ease-in-out infinite;
     background-color: var(--color-primary-500);
     box-shadow: 0 0 12px rgba(51, 102, 204, 0.45);
+    transition: width 180ms ease-out;
 }
 
 .page-navigation-loading::-moz-progress-bar {
-    animation: page-navigation-loading-pulse 1.5s ease-in-out infinite;
     background-color: var(--color-primary-500);
     box-shadow: 0 0 12px rgba(51, 102, 204, 0.45);
-}
-
-@keyframes page-navigation-loading-pulse {
-    50% {
-        opacity: 0.5;
-    }
+    transition: width 180ms ease-out;
 }
 
 /* Scrollbar theming for light/dark modes */

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -261,6 +261,10 @@ html {
         z-index: 60;
     }
 
+    .z-stack-loading {
+        z-index: 65;
+    }
+
     .px-mobile-safe {
         padding-left: calc(1rem + env(safe-area-inset-left, 0px));
         padding-right: calc(1rem + env(safe-area-inset-right, 0px));

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -49,6 +49,44 @@ if (typeof document !== 'undefined') {
 
         document.body.addEventListener('htmx:afterSwap', initFlowbiteWithPatches);
 
+        const pageNavigationLoading = document.getElementById('page-navigation-loading');
+
+        const isPageContainerRequest = (event) => {
+            const target = event?.detail?.target;
+
+            return target?.id === 'page-container';
+        };
+
+        if (pageNavigationLoading) {
+            const showPageNavigationLoading = () => {
+                pageNavigationLoading.classList.remove('opacity-0');
+                pageNavigationLoading.classList.add('opacity-100');
+                pageNavigationLoading.setAttribute('aria-hidden', 'false');
+            };
+
+            const hidePageNavigationLoading = () => {
+                pageNavigationLoading.classList.remove('opacity-100');
+                pageNavigationLoading.classList.add('opacity-0');
+                pageNavigationLoading.setAttribute('aria-hidden', 'true');
+            };
+
+            document.body.addEventListener('htmx:beforeRequest', (event) => {
+                if (isPageContainerRequest(event)) {
+                    showPageNavigationLoading();
+                }
+            });
+
+            const hideIfPageContainerRequest = (event) => {
+                if (isPageContainerRequest(event)) {
+                    hidePageNavigationLoading();
+                }
+            };
+
+            document.body.addEventListener('htmx:afterSwap', hideIfPageContainerRequest);
+            document.body.addEventListener('htmx:responseError', hideIfPageContainerRequest);
+            document.body.addEventListener('htmx:sendError', hideIfPageContainerRequest);
+        }
+
         // Close all Flowbite dropdowns when a major HTMX navigation occurs
         document.body.addEventListener('htmx:beforeRequest', (event) => {
             const target = event.detail.target;

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -57,40 +57,41 @@ if (typeof document !== 'undefined') {
             return target?.id === 'page-container';
         };
 
-        if (pageNavigationLoading) {
-            const showPageNavigationLoading = () => {
+        const showPageNavigationLoading = () => {
+            if (pageNavigationLoading) {
                 pageNavigationLoading.classList.remove('opacity-0');
                 pageNavigationLoading.classList.add('opacity-100');
                 pageNavigationLoading.setAttribute('aria-hidden', 'false');
-            };
+            }
+        };
 
-            const hidePageNavigationLoading = () => {
+        const hidePageNavigationLoading = () => {
+            if (pageNavigationLoading) {
                 pageNavigationLoading.classList.remove('opacity-100');
                 pageNavigationLoading.classList.add('opacity-0');
                 pageNavigationLoading.setAttribute('aria-hidden', 'true');
-            };
+            }
+        };
 
-            document.body.addEventListener('htmx:beforeRequest', (event) => {
-                if (isPageContainerRequest(event)) {
-                    showPageNavigationLoading();
-                }
-            });
+        const hideIfPageContainerRequest = (event) => {
+            if (isPageContainerRequest(event)) {
+                hidePageNavigationLoading();
+            }
+        };
 
-            const hideIfPageContainerRequest = (event) => {
-                if (isPageContainerRequest(event)) {
-                    hidePageNavigationLoading();
-                }
-            };
-
-            document.body.addEventListener('htmx:afterSwap', hideIfPageContainerRequest);
-            document.body.addEventListener('htmx:responseError', hideIfPageContainerRequest);
-            document.body.addEventListener('htmx:sendError', hideIfPageContainerRequest);
-        }
+        document.body.addEventListener('htmx:afterRequest', hideIfPageContainerRequest);
 
         // Close all Flowbite dropdowns when a major HTMX navigation occurs
         document.body.addEventListener('htmx:beforeRequest', (event) => {
             const target = event.detail.target;
-            if (target?.id === 'page-container' && typeof FlowbiteInstances !== 'undefined') {
+
+            if (target?.id !== 'page-container') {
+                return;
+            }
+
+            showPageNavigationLoading();
+
+            if (typeof FlowbiteInstances !== 'undefined') {
                 const dropdowns = FlowbiteInstances.getInstances('Dropdown');
                 if (dropdowns) {
                     Object.values(dropdowns).forEach(instance => {

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -57,19 +57,61 @@ if (typeof document !== 'undefined') {
             return target?.id === 'page-container';
         };
 
+        let pageNavigationLoadingStartedAt = 0;
+        let pageNavigationLoadingRampFrame = null;
+        let pageNavigationLoadingFinishTimeout = null;
+        let pageNavigationLoadingHideTimeout = null;
+
+        const clearPageNavigationLoadingTimers = () => {
+            if (pageNavigationLoadingRampFrame) {
+                window.cancelAnimationFrame(pageNavigationLoadingRampFrame);
+                pageNavigationLoadingRampFrame = null;
+            }
+
+            window.clearTimeout(pageNavigationLoadingFinishTimeout);
+            window.clearTimeout(pageNavigationLoadingHideTimeout);
+        };
+
         const showPageNavigationLoading = () => {
             if (pageNavigationLoading) {
+                clearPageNavigationLoadingTimers();
+                pageNavigationLoadingStartedAt = Date.now();
+                pageNavigationLoading.value = 0;
                 pageNavigationLoading.classList.remove('opacity-0');
                 pageNavigationLoading.classList.add('opacity-100');
                 pageNavigationLoading.setAttribute('aria-hidden', 'false');
+
+                pageNavigationLoadingRampFrame = window.requestAnimationFrame(() => {
+                    pageNavigationLoading.value = 70;
+                    pageNavigationLoadingRampFrame = null;
+                });
             }
         };
 
         const hidePageNavigationLoading = () => {
             if (pageNavigationLoading) {
-                pageNavigationLoading.classList.remove('opacity-100');
-                pageNavigationLoading.classList.add('opacity-0');
-                pageNavigationLoading.setAttribute('aria-hidden', 'true');
+                window.clearTimeout(pageNavigationLoadingFinishTimeout);
+                window.clearTimeout(pageNavigationLoadingHideTimeout);
+
+                const minimumVisibleDuration = 180;
+                const elapsed = Date.now() - pageNavigationLoadingStartedAt;
+                const finishDelay = Math.max(minimumVisibleDuration - elapsed, 0);
+
+                pageNavigationLoadingFinishTimeout = window.setTimeout(() => {
+                    if (pageNavigationLoadingRampFrame) {
+                        window.cancelAnimationFrame(pageNavigationLoadingRampFrame);
+                        pageNavigationLoadingRampFrame = null;
+                    }
+
+                    pageNavigationLoading.value = 100;
+
+                    pageNavigationLoadingHideTimeout = window.setTimeout(() => {
+                        pageNavigationLoading.classList.remove('opacity-100');
+                        pageNavigationLoading.classList.add('opacity-0');
+                        pageNavigationLoading.setAttribute('aria-hidden', 'true');
+                        pageNavigationLoading.value = 0;
+                    }, 220);
+                }, finishDelay);
             }
         };
 

--- a/resources/views/layouts/authenticated.blade.php
+++ b/resources/views/layouts/authenticated.blade.php
@@ -55,7 +55,7 @@
 
 <body class="bg-[#F5F7FA] dark:bg-gray-900 text-gray-600 min-h-screen font-sans antialiased transition-colors">
     <progress id="page-navigation-loading" data-page-navigation-loading aria-label="Page loading" aria-hidden="true"
-        max="100" value="100"
+        max="100" value="0"
         class="page-navigation-loading pointer-events-none fixed inset-x-0 top-0 z-stack-loading h-1 w-full opacity-0 transition-opacity duration-150">
         Page loading
     </progress>

--- a/resources/views/layouts/authenticated.blade.php
+++ b/resources/views/layouts/authenticated.blade.php
@@ -54,6 +54,12 @@
 </head>
 
 <body class="bg-[#F5F7FA] dark:bg-gray-900 text-gray-600 min-h-screen font-sans antialiased transition-colors">
+    <div id="page-navigation-loading" data-page-navigation-loading role="progressbar" aria-label="Page loading"
+        aria-hidden="true"
+        class="pointer-events-none fixed inset-x-0 top-0 z-stack-loading h-1 opacity-0 transition-opacity duration-150">
+        <div class="h-full w-full animate-pulse bg-primary-500 shadow-[0_0_12px_rgba(51,102,204,0.45)]"></div>
+    </div>
+
     <div class="flex h-screen">
         <!-- Desktop: Sidebar and Navbar -->
         <div class="hidden lg:flex">

--- a/resources/views/layouts/authenticated.blade.php
+++ b/resources/views/layouts/authenticated.blade.php
@@ -54,11 +54,11 @@
 </head>
 
 <body class="bg-[#F5F7FA] dark:bg-gray-900 text-gray-600 min-h-screen font-sans antialiased transition-colors">
-    <div id="page-navigation-loading" data-page-navigation-loading role="progressbar" aria-label="Page loading"
-        aria-hidden="true"
-        class="pointer-events-none fixed inset-x-0 top-0 z-stack-loading h-1 opacity-0 transition-opacity duration-150">
-        <div class="h-full w-full animate-pulse bg-primary-500 shadow-[0_0_12px_rgba(51,102,204,0.45)]"></div>
-    </div>
+    <progress id="page-navigation-loading" data-page-navigation-loading aria-label="Page loading" aria-hidden="true"
+        max="100" value="100"
+        class="page-navigation-loading pointer-events-none fixed inset-x-0 top-0 z-stack-loading h-1 w-full opacity-0 transition-opacity duration-150">
+        Page loading
+    </progress>
 
     <div class="flex h-screen">
         <!-- Desktop: Sidebar and Navbar -->

--- a/tests/Feature/NavigationTest.php
+++ b/tests/Feature/NavigationTest.php
@@ -193,12 +193,16 @@ describe('HTMX Navigation Requests', function () {
         $dashboardResponse->assertSee('<progress', false);
         $dashboardResponse->assertSee('id="page-navigation-loading"', false);
         $dashboardResponse->assertSee('data-page-navigation-loading', false);
+        $dashboardResponse->assertSee('max="100"', false);
+        $dashboardResponse->assertSee('value="0"', false);
 
         $script = file_get_contents(resource_path('js/app.js'));
 
         expect($script)
             ->toContain("document.getElementById('page-navigation-loading')")
             ->toContain("target?.id === 'page-container'")
+            ->toContain('pageNavigationLoading.value = 70')
+            ->toContain('pageNavigationLoading.value = 100')
             ->toContain("document.body.addEventListener('htmx:beforeRequest'")
             ->toContain("document.body.addEventListener('htmx:afterRequest', hideIfPageContainerRequest)");
 

--- a/tests/Feature/NavigationTest.php
+++ b/tests/Feature/NavigationTest.php
@@ -183,6 +183,38 @@ describe('HTMX Navigation Requests', function () {
         $response->assertSee('hx-target="#page-container"', false);
         $response->assertSee('id="page-container"', false);
     });
+
+    it('renders global page navigation loading feedback hooks', function () {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get('/dashboard');
+
+        $response->assertSuccessful();
+        $response->assertSee('id="page-navigation-loading"', false);
+        $response->assertSee('role="progressbar"', false);
+        $response->assertSee('data-page-navigation-loading', false);
+
+        $script = file_get_contents(resource_path('js/app.js'));
+
+        expect($script)
+            ->toContain("document.getElementById('page-navigation-loading')")
+            ->toContain("target?.id === 'page-container'")
+            ->toContain("document.body.addEventListener('htmx:beforeRequest'")
+            ->toContain("document.body.addEventListener('htmx:afterSwap', hideIfPageContainerRequest)")
+            ->toContain("document.body.addEventListener('htmx:responseError', hideIfPageContainerRequest)")
+            ->toContain("document.body.addEventListener('htmx:sendError', hideIfPageContainerRequest)");
+    });
+
+    it('keeps the log form save loading indicator scoped to the form action', function () {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get(route('logs.create'));
+
+        $response->assertSuccessful();
+        $response->assertSee('hx-indicator="#save-loading"', false);
+        $response->assertSee('id="save-loading"', false);
+        $response->assertSee('htmx-indicator-hidden">Log Reading', false);
+    });
 });
 
 describe('Navigation Routes', function () {

--- a/tests/Feature/NavigationTest.php
+++ b/tests/Feature/NavigationTest.php
@@ -184,15 +184,15 @@ describe('HTMX Navigation Requests', function () {
         $response->assertSee('id="page-container"', false);
     });
 
-    it('renders global page navigation loading feedback hooks', function () {
+    it('renders global page navigation loading feedback without replacing form save indicators', function () {
         $user = User::factory()->create();
 
-        $response = $this->actingAs($user)->get('/dashboard');
+        $dashboardResponse = $this->actingAs($user)->get('/dashboard');
 
-        $response->assertSuccessful();
-        $response->assertSee('id="page-navigation-loading"', false);
-        $response->assertSee('role="progressbar"', false);
-        $response->assertSee('data-page-navigation-loading', false);
+        $dashboardResponse->assertSuccessful();
+        $dashboardResponse->assertSee('<progress', false);
+        $dashboardResponse->assertSee('id="page-navigation-loading"', false);
+        $dashboardResponse->assertSee('data-page-navigation-loading', false);
 
         $script = file_get_contents(resource_path('js/app.js'));
 
@@ -200,13 +200,7 @@ describe('HTMX Navigation Requests', function () {
             ->toContain("document.getElementById('page-navigation-loading')")
             ->toContain("target?.id === 'page-container'")
             ->toContain("document.body.addEventListener('htmx:beforeRequest'")
-            ->toContain("document.body.addEventListener('htmx:afterSwap', hideIfPageContainerRequest)")
-            ->toContain("document.body.addEventListener('htmx:responseError', hideIfPageContainerRequest)")
-            ->toContain("document.body.addEventListener('htmx:sendError', hideIfPageContainerRequest)");
-    });
-
-    it('keeps the log form save loading indicator scoped to the form action', function () {
-        $user = User::factory()->create();
+            ->toContain("document.body.addEventListener('htmx:afterRequest', hideIfPageContainerRequest)");
 
         $response = $this->actingAs($user)->get(route('logs.create'));
 


### PR DESCRIPTION
## Summary
- Added a lightweight top loading bar for HTMX navigation requests targeting `#page-container`
- Cleans up the indicator on successful swaps as well as request/send errors
- Kept form-specific `hx-indicator` behavior scoped to the log form
- Added focused feature coverage for the navigation hook and the existing save indicator

## Testing
- `php artisan test --compact tests/Feature/NavigationTest.php`
- `vendor/bin/pint --dirty --format agent`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visual loading indicator that displays at the top of the page during navigation, showing real-time progress feedback to enhance user experience.

* **Tests**
  * Added feature tests to verify the loading indicator displays correctly during page navigation with proper initialization and cleanup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Orlando-Villanueva/delight/pull/133?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->