### PR TITLE
[DEL-260] Hide navigation loader before reset

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -61,15 +61,34 @@ if (typeof document !== 'undefined') {
         let pageNavigationLoadingRampFrame = null;
         let pageNavigationLoadingFinishTimeout = null;
         let pageNavigationLoadingHideTimeout = null;
+        let pageNavigationLoadingResetTimeout = null;
 
         const clearPageNavigationLoadingTimers = () => {
             if (pageNavigationLoadingRampFrame) {
-                window.cancelAnimationFrame(pageNavigationLoadingRampFrame);
+                globalThis.cancelAnimationFrame(pageNavigationLoadingRampFrame);
                 pageNavigationLoadingRampFrame = null;
             }
 
-            window.clearTimeout(pageNavigationLoadingFinishTimeout);
-            window.clearTimeout(pageNavigationLoadingHideTimeout);
+            globalThis.clearTimeout(pageNavigationLoadingFinishTimeout);
+            globalThis.clearTimeout(pageNavigationLoadingHideTimeout);
+            globalThis.clearTimeout(pageNavigationLoadingResetTimeout);
+        };
+
+        const resetPageNavigationLoading = () => {
+            pageNavigationLoading.value = 0;
+        };
+
+        const hideFinishedPageNavigationLoading = () => {
+            pageNavigationLoading.classList.remove('opacity-100');
+            pageNavigationLoading.classList.add('opacity-0');
+            pageNavigationLoading.setAttribute('aria-hidden', 'true');
+
+            pageNavigationLoadingResetTimeout = globalThis.setTimeout(resetPageNavigationLoading, 180);
+        };
+
+        const finishPageNavigationLoading = () => {
+            pageNavigationLoading.value = 100;
+            pageNavigationLoadingHideTimeout = globalThis.setTimeout(hideFinishedPageNavigationLoading, 220);
         };
 
         const showPageNavigationLoading = () => {
@@ -81,7 +100,7 @@ if (typeof document !== 'undefined') {
                 pageNavigationLoading.classList.add('opacity-100');
                 pageNavigationLoading.setAttribute('aria-hidden', 'false');
 
-                pageNavigationLoadingRampFrame = window.requestAnimationFrame(() => {
+                pageNavigationLoadingRampFrame = globalThis.requestAnimationFrame(() => {
                     pageNavigationLoading.value = 70;
                     pageNavigationLoadingRampFrame = null;
                 });
@@ -90,28 +109,13 @@ if (typeof document !== 'undefined') {
 
         const hidePageNavigationLoading = () => {
             if (pageNavigationLoading) {
-                window.clearTimeout(pageNavigationLoadingFinishTimeout);
-                window.clearTimeout(pageNavigationLoadingHideTimeout);
+                clearPageNavigationLoadingTimers();
 
                 const minimumVisibleDuration = 180;
                 const elapsed = Date.now() - pageNavigationLoadingStartedAt;
                 const finishDelay = Math.max(minimumVisibleDuration - elapsed, 0);
 
-                pageNavigationLoadingFinishTimeout = window.setTimeout(() => {
-                    if (pageNavigationLoadingRampFrame) {
-                        window.cancelAnimationFrame(pageNavigationLoadingRampFrame);
-                        pageNavigationLoadingRampFrame = null;
-                    }
-
-                    pageNavigationLoading.value = 100;
-
-                    pageNavigationLoadingHideTimeout = window.setTimeout(() => {
-                        pageNavigationLoading.classList.remove('opacity-100');
-                        pageNavigationLoading.classList.add('opacity-0');
-                        pageNavigationLoading.setAttribute('aria-hidden', 'true');
-                        pageNavigationLoading.value = 0;
-                    }, 220);
-                }, finishDelay);
+                pageNavigationLoadingFinishTimeout = globalThis.setTimeout(finishPageNavigationLoading, finishDelay);
             }
         };
 


### PR DESCRIPTION
## Summary
- Delay resetting the DEL-260 simulated HTMX navigation progress value until after the top loading bar has faded out.
- Flatten the timer cleanup flow so the loading animation cleanup is consistent and easier to maintain.
- Keeps the visible sequence as 0 -> 70 -> 100 -> fade out, avoiding the visible 100 -> 0 shrink on fast navigations.

## Testing
- `php artisan test --compact tests/Feature/NavigationTest.php`
- `vendor/bin/pint --dirty --format agent`
- `npm run build`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored page navigation loading overlay timing logic with improved code organization and internal state management. No user-visible changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Orlando-Villanueva/delight/pull/134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->