### PR TITLE
[DEL-256] Add Brave-specific guidance for push subscription failures

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -307,6 +307,8 @@ if (typeof document !== 'undefined') {
             try {
                 return await navigator.brave.isBrave();
             } catch (error) {
+                console.error('Brave detection failed', error);
+
                 return false;
             }
         };

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -299,6 +299,9 @@ if (typeof document !== 'undefined') {
             && 'PushManager' in window
             && 'Notification' in window;
 
+        const isBraveBrowser = () => Boolean(navigator.brave)
+            && typeof navigator.brave.isBrave === 'function';
+
         const urlBase64ToUint8Array = (base64String) => {
             const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
             const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
@@ -510,6 +513,20 @@ if (typeof document !== 'undefined') {
                 setStatus(statusMessage, true);
 
                 setNotice(errorNotice, message);
+            };
+
+            const getPushSubscriptionFailureMessage = () => {
+                if (isBraveBrowser()) {
+                    return {
+                        message: 'Brave could not connect to its push service. In Brave, enable Settings > Privacy and security > Use Google services for push messaging, then reload Delight and try again.',
+                        statusMessage: 'Brave could not connect to its push service.',
+                    };
+                }
+
+                return {
+                    message: 'This browser allowed notifications, but could not create a push subscription. Reload Delight and try again. If it repeats, the browser push service may be blocked or unavailable for this profile or network.',
+                    statusMessage: 'Browser could not create a push subscription.',
+                };
             };
 
             const requestPermissionWithTimeout = () => new Promise((resolve, reject) => {
@@ -759,10 +776,12 @@ if (typeof document !== 'undefined') {
                         }
 
                         if (error?.name === 'AbortError') {
+                            const failureMessage = getPushSubscriptionFailureMessage();
+
                             setEnabledState(false, previousAccountHasDevices, false);
                             showError(
-                                'This browser allowed notifications, but could not create a push subscription. Reload Delight and try again. If it repeats, the browser push service may be blocked or unavailable for this profile or network.',
-                                'Browser could not create a push subscription.',
+                                failureMessage.message,
+                                failureMessage.statusMessage,
                             );
 
                             return;

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -299,8 +299,17 @@ if (typeof document !== 'undefined') {
             && 'PushManager' in window
             && 'Notification' in window;
 
-        const isBraveBrowser = () => Boolean(navigator.brave)
-            && typeof navigator.brave.isBrave === 'function';
+        const isBraveBrowser = async () => {
+            if (!navigator.brave || typeof navigator.brave.isBrave !== 'function') {
+                return false;
+            }
+
+            try {
+                return await navigator.brave.isBrave();
+            } catch (error) {
+                return false;
+            }
+        };
 
         const urlBase64ToUint8Array = (base64String) => {
             const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
@@ -515,8 +524,8 @@ if (typeof document !== 'undefined') {
                 setNotice(errorNotice, message);
             };
 
-            const getPushSubscriptionFailureMessage = () => {
-                if (isBraveBrowser()) {
+            const getPushSubscriptionFailureMessage = async () => {
+                if (await isBraveBrowser()) {
                     return {
                         message: 'Brave could not connect to its push service. In Brave, enable Settings > Privacy and security > Use Google services for push messaging, then reload Delight and try again.',
                         statusMessage: 'Brave could not connect to its push service.',
@@ -776,7 +785,7 @@ if (typeof document !== 'undefined') {
                         }
 
                         if (error?.name === 'AbortError') {
-                            const failureMessage = getPushSubscriptionFailureMessage();
+                            const failureMessage = await getPushSubscriptionFailureMessage();
 
                             setEnabledState(false, previousAccountHasDevices, false);
                             showError(

--- a/tests/Unit/ReadingReminderSettingsJavascriptTest.php
+++ b/tests/Unit/ReadingReminderSettingsJavascriptTest.php
@@ -1,7 +1,12 @@
 <?php
 
+function readingReminderSettingsJavascript(): string
+{
+    return file_get_contents(__DIR__.'/../../resources/js/app.js');
+}
+
 it('restores previous reminder device state when current-device unsubscribe fails', function () {
-    $javascript = file_get_contents(__DIR__.'/../../resources/js/app.js');
+    $javascript = readingReminderSettingsJavascript();
 
     expect($javascript)->toContain('previousDeviceEnabled')
         ->and($javascript)->toContain('previousAccountHasDevices')
@@ -10,7 +15,7 @@ it('restores previous reminder device state when current-device unsubscribe fail
 });
 
 it('keeps reminder setup retryable when browser permission is dismissed', function () {
-    $javascript = file_get_contents(__DIR__.'/../../resources/js/app.js');
+    $javascript = readingReminderSettingsJavascript();
 
     expect($javascript)->toContain("if (permission === 'denied')")
         ->and($javascript)->toContain('Browser permission was not enabled.')
@@ -19,7 +24,7 @@ it('keeps reminder setup retryable when browser permission is dismissed', functi
 });
 
 it('gives Brave users actionable guidance when the push service registration fails', function () {
-    $javascript = file_get_contents(__DIR__.'/../../resources/js/app.js');
+    $javascript = readingReminderSettingsJavascript();
 
     expect($javascript)->toContain('const isBraveBrowser = async ()')
         ->and($javascript)->toContain('return await navigator.brave.isBrave()')

--- a/tests/Unit/ReadingReminderSettingsJavascriptTest.php
+++ b/tests/Unit/ReadingReminderSettingsJavascriptTest.php
@@ -21,8 +21,10 @@ it('keeps reminder setup retryable when browser permission is dismissed', functi
 it('gives Brave users actionable guidance when the push service registration fails', function () {
     $javascript = file_get_contents(__DIR__.'/../../resources/js/app.js');
 
-    expect($javascript)->toContain('isBraveBrowser')
+    expect($javascript)->toContain('const isBraveBrowser = async ()')
+        ->and($javascript)->toContain('return await navigator.brave.isBrave()')
         ->and($javascript)->toContain('Use Google services for push messaging')
         ->and($javascript)->toContain('Brave could not connect to its push service.')
-        ->and($javascript)->toContain('getPushSubscriptionFailureMessage');
+        ->and($javascript)->toContain('const getPushSubscriptionFailureMessage = async ()')
+        ->and($javascript)->toContain('await getPushSubscriptionFailureMessage()');
 });

--- a/tests/Unit/ReadingReminderSettingsJavascriptTest.php
+++ b/tests/Unit/ReadingReminderSettingsJavascriptTest.php
@@ -17,3 +17,12 @@ it('keeps reminder setup retryable when browser permission is dismissed', functi
         ->and($javascript)->toContain('setEnabledState(false, previousAccountHasDevices)')
         ->and($javascript)->not->toContain('if (permission !== \'granted\') {'.PHP_EOL.'                            setEnabledState(false, false);'.PHP_EOL.'                            showBlocked();');
 });
+
+it('gives Brave users actionable guidance when the push service registration fails', function () {
+    $javascript = file_get_contents(__DIR__.'/../../resources/js/app.js');
+
+    expect($javascript)->toContain('isBraveBrowser')
+        ->and($javascript)->toContain('Use Google services for push messaging')
+        ->and($javascript)->toContain('Brave could not connect to its push service.')
+        ->and($javascript)->toContain('getPushSubscriptionFailureMessage');
+});


### PR DESCRIPTION
## Summary
- Detect Brave in the reminder setup flow using the browser-provided `navigator.brave` API.
- Show Brave users a specific recovery message when push subscription registration fails, pointing them to `Settings > Privacy and security > Use Google services for push messaging`.
- Keep the existing generic push-failure copy for other browsers.
- Add a focused unit test to pin the Brave-specific guidance in the settings JavaScript.

## Testing
- `php artisan test --compact tests/Unit/ReadingReminderSettingsJavascriptTest.php tests/Feature/SettingsPushPreferenceTest.php`
- `npm run build`
- `vendor/bin/pint --dirty --format agent`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messaging when push subscription creation fails, providing Brave users with actionable guidance instead of generic error text.

* **Tests**
  * Added test coverage for Brave browser detection and browser-specific push subscription failure messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->