### PR TITLE
[DEL-256] Add per-subscription web push delivery reports

### DIFF
--- a/app/Jobs/SendReadingReminderPush.php
+++ b/app/Jobs/SendReadingReminderPush.php
@@ -53,7 +53,8 @@ class SendReadingReminderPush implements ShouldQueue
         $user->notify(new ReadingReminderPushNotification(
             $delivery->reminder_type,
             $delivery->reminder_date->toDateString(),
-            $this->targetUrlFor($user)
+            $this->targetUrlFor($user),
+            $delivery->id
         ));
 
         $delivery->forceFill(['sent_at' => now()])->save();

--- a/app/Listeners/RecordPushReminderDeliveryReport.php
+++ b/app/Listeners/RecordPushReminderDeliveryReport.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Models\PushReminderDelivery;
+use App\Models\PushReminderDeliveryReport;
+use Illuminate\Support\Str;
+use NotificationChannels\WebPush\Events\NotificationFailed;
+use NotificationChannels\WebPush\Events\NotificationSent;
+
+class RecordPushReminderDeliveryReport
+{
+    public function handle(NotificationSent|NotificationFailed $event): void
+    {
+        $message = $event->message->toArray();
+        $data = is_array($message['data'] ?? null) ? $message['data'] : [];
+        $userId = $this->userIdFromSubscription($event);
+        $delivery = $this->deliveryFrom($data, $userId);
+        $endpoint = $event->subscription->endpoint;
+        $response = $event->report->getResponse();
+        $responseBody = $response?->getBody()->__toString();
+
+        PushReminderDeliveryReport::query()->create([
+            'push_reminder_delivery_id' => $delivery?->id,
+            'user_id' => $delivery?->user_id ?? $userId,
+            'reminder_type' => $delivery?->reminder_type ?? $this->nullableString($data['reminderType'] ?? null),
+            'reminder_date' => $delivery?->reminder_date ?? $this->nullableString($data['reminderDate'] ?? null),
+            'push_subscription_id' => $event->subscription->id,
+            'endpoint_host' => parse_url($endpoint, PHP_URL_HOST) ?: null,
+            'endpoint_hash' => hash('sha256', $endpoint),
+            'status' => $event instanceof NotificationSent
+                ? PushReminderDeliveryReport::STATUS_SENT
+                : PushReminderDeliveryReport::STATUS_FAILED,
+            'http_status' => $response?->getStatusCode(),
+            'expired' => $event->report->isSubscriptionExpired(),
+            'failure_reason' => $event instanceof NotificationFailed
+                ? Str::limit($event->report->getReason(), 255, '')
+                : null,
+            'response_body' => $responseBody !== null && $responseBody !== ''
+                ? Str::limit($responseBody, 4096, '')
+                : null,
+            'reported_at' => now(),
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    private function deliveryFrom(array $data, ?int $userId): ?PushReminderDelivery
+    {
+        $deliveryId = $data['deliveryId'] ?? null;
+
+        if (is_int($deliveryId) || is_string($deliveryId)) {
+            return PushReminderDelivery::query()->find($deliveryId);
+        }
+
+        $reminderType = $this->nullableString($data['reminderType'] ?? null);
+        $reminderDate = $this->nullableString($data['reminderDate'] ?? null);
+
+        if ($userId === null || $reminderType === null || $reminderDate === null) {
+            return null;
+        }
+
+        return PushReminderDelivery::query()
+            ->where('user_id', $userId)
+            ->where('reminder_type', $reminderType)
+            ->whereDate('reminder_date', $reminderDate)
+            ->first();
+    }
+
+    private function userIdFromSubscription(NotificationSent|NotificationFailed $event): ?int
+    {
+        if ($event->subscription->subscribable_id === null) {
+            return null;
+        }
+
+        return (int) $event->subscription->subscribable_id;
+    }
+
+    private function nullableString(mixed $value): ?string
+    {
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+}

--- a/app/Listeners/RecordPushReminderDeliveryReport.php
+++ b/app/Listeners/RecordPushReminderDeliveryReport.php
@@ -18,7 +18,7 @@ class RecordPushReminderDeliveryReport
         $delivery = $this->deliveryFrom($data, $userId);
         $endpoint = $event->subscription->endpoint;
         $response = $event->report->getResponse();
-        $responseBody = $response?->getBody()->__toString();
+        $responseBody = $response?->getBody()?->__toString();
 
         PushReminderDeliveryReport::query()->create([
             'push_reminder_delivery_id' => $delivery?->id,

--- a/app/Models/PushReminderDeliveryReport.php
+++ b/app/Models/PushReminderDeliveryReport.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PushReminderDeliveryReport extends Model
+{
+    public const string STATUS_SENT = 'sent';
+
+    public const string STATUS_FAILED = 'failed';
+
+    protected $fillable = [
+        'push_reminder_delivery_id',
+        'user_id',
+        'reminder_type',
+        'reminder_date',
+        'push_subscription_id',
+        'endpoint_host',
+        'endpoint_hash',
+        'status',
+        'http_status',
+        'expired',
+        'failure_reason',
+        'response_body',
+        'reported_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'reminder_date' => 'date',
+            'expired' => 'boolean',
+            'reported_at' => 'datetime',
+        ];
+    }
+
+    public function delivery(): BelongsTo
+    {
+        return $this->belongsTo(PushReminderDelivery::class, 'push_reminder_delivery_id');
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Notifications/ReadingReminderPushNotification.php
+++ b/app/Notifications/ReadingReminderPushNotification.php
@@ -15,7 +15,8 @@ class ReadingReminderPushNotification extends Notification
     public function __construct(
         private string $reminderType,
         private string $reminderDate,
-        private string $targetUrl
+        private string $targetUrl,
+        private ?int $deliveryId = null
     ) {}
 
     /**
@@ -38,6 +39,7 @@ class ReadingReminderPushNotification extends Notification
             ->tag('delight-'.$this->reminderType.'-'.$this->reminderDate)
             ->data([
                 'url' => $this->targetUrl,
+                'deliveryId' => $this->deliveryId,
                 'reminderType' => $this->reminderType,
                 'reminderDate' => $this->reminderDate,
             ])
@@ -52,6 +54,7 @@ class ReadingReminderPushNotification extends Notification
         return [
             'reminder_type' => $this->reminderType,
             'reminder_date' => $this->reminderDate,
+            'delivery_id' => $this->deliveryId,
             'target_url' => $this->targetUrl,
         ];
     }

--- a/database/migrations/2026_06_01_162348_create_push_reminder_delivery_reports_table.php
+++ b/database/migrations/2026_06_01_162348_create_push_reminder_delivery_reports_table.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('push_reminder_delivery_reports', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('push_reminder_delivery_id')->nullable()->constrained('push_reminder_deliveries')->nullOnDelete();
+            $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete();
+            $table->string('reminder_type', 32)->nullable();
+            $table->date('reminder_date')->nullable();
+            $table->unsignedBigInteger('push_subscription_id')->nullable();
+            $table->string('endpoint_host')->nullable();
+            $table->char('endpoint_hash', 64)->nullable();
+            $table->string('status', 16);
+            $table->unsignedSmallInteger('http_status')->nullable();
+            $table->boolean('expired')->default(false);
+            $table->string('failure_reason')->nullable();
+            $table->text('response_body')->nullable();
+            $table->timestamp('reported_at');
+            $table->timestamps();
+
+            $table->index(['push_reminder_delivery_id', 'status'], 'idx_push_report_delivery_status');
+            $table->index(['user_id', 'reminder_type', 'reminder_date'], 'idx_push_report_user_reminder');
+            $table->index(['push_subscription_id'], 'idx_push_report_subscription');
+            $table->index(['endpoint_host', 'status'], 'idx_push_report_endpoint_status');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('push_reminder_delivery_reports');
+    }
+};

--- a/tests/Feature/PushReminderDeliveryReportTest.php
+++ b/tests/Feature/PushReminderDeliveryReportTest.php
@@ -1,0 +1,177 @@
+<?php
+
+use App\Listeners\RecordPushReminderDeliveryReport;
+use App\Models\PushReminderDelivery;
+use App\Models\PushReminderDeliveryReport;
+use App\Models\User;
+use App\Notifications\ReadingReminderPushNotification;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Minishlink\WebPush\MessageSentReport;
+use NotificationChannels\WebPush\Events\NotificationFailed;
+use NotificationChannels\WebPush\Events\NotificationSent;
+use NotificationChannels\WebPush\PushSubscription;
+use NotificationChannels\WebPush\WebPushMessage;
+
+it('records successful webpush reports for a reminder delivery subscription', function () {
+    $user = User::factory()->create();
+    $subscription = pushSubscriptionFor($user, 'https://fcm.googleapis.com/fcm/send/success-token');
+    $delivery = pushDeliveryFor($user);
+
+    $message = reminderMessageFor($user, $delivery);
+    $event = new NotificationSent(
+        new MessageSentReport(
+            new Request('POST', $subscription->endpoint),
+            new Response(201, [], 'accepted'),
+        ),
+        $subscription,
+        $message,
+    );
+
+    (new RecordPushReminderDeliveryReport)->handle($event);
+
+    $report = PushReminderDeliveryReport::query()->sole();
+
+    expect($report->push_reminder_delivery_id)->toBe($delivery->id)
+        ->and($report->user_id)->toBe($user->id)
+        ->and($report->reminder_type)->toBe(PushReminderDelivery::TYPE_DAILY_READING)
+        ->and($report->reminder_date->toDateString())->toBe('2026-06-01')
+        ->and($report->push_subscription_id)->toBe($subscription->id)
+        ->and($report->endpoint_host)->toBe('fcm.googleapis.com')
+        ->and($report->endpoint_hash)->toBe(hash('sha256', $subscription->endpoint))
+        ->and($report->status)->toBe(PushReminderDeliveryReport::STATUS_SENT)
+        ->and($report->http_status)->toBe(201)
+        ->and($report->expired)->toBeFalse()
+        ->and($report->failure_reason)->toBeNull()
+        ->and($report->reported_at)->not->toBeNull();
+});
+
+it('records failed webpush reports without deleting non-expired subscription evidence', function () {
+    $user = User::factory()->create();
+    $subscription = pushSubscriptionFor($user, 'https://fcm.googleapis.com/fcm/send/failure-token');
+    $delivery = pushDeliveryFor($user);
+
+    $message = reminderMessageFor($user, $delivery);
+    $event = new NotificationFailed(
+        new MessageSentReport(
+            new Request('POST', $subscription->endpoint),
+            new Response(403, [], 'VAPID credentials rejected'),
+            false,
+            'Client error: 403 Forbidden',
+        ),
+        $subscription,
+        $message,
+    );
+
+    (new RecordPushReminderDeliveryReport)->handle($event);
+
+    $report = PushReminderDeliveryReport::query()->sole();
+
+    expect($report->push_reminder_delivery_id)->toBe($delivery->id)
+        ->and($report->push_subscription_id)->toBe($subscription->id)
+        ->and($report->status)->toBe(PushReminderDeliveryReport::STATUS_FAILED)
+        ->and($report->http_status)->toBe(403)
+        ->and($report->expired)->toBeFalse()
+        ->and($report->failure_reason)->toBe('Client error: 403 Forbidden')
+        ->and($report->response_body)->toBe('VAPID credentials rejected');
+
+    expect($user->pushSubscriptions()->whereKey($subscription->id)->exists())->toBeTrue();
+});
+
+it('records expired endpoint reports after the subscription row has already been deleted', function () {
+    $user = User::factory()->create();
+    $subscription = pushSubscriptionFor($user, 'https://fcm.googleapis.com/fcm/send/expired-token');
+    $subscriptionId = $subscription->id;
+    $delivery = pushDeliveryFor($user);
+
+    $message = reminderMessageFor($user, $delivery);
+    $subscription->delete();
+
+    $event = new NotificationFailed(
+        new MessageSentReport(
+            new Request('POST', $subscription->endpoint),
+            new Response(410, [], 'push subscription expired'),
+            false,
+            'Client error: 410 Gone',
+        ),
+        $subscription,
+        $message,
+    );
+
+    (new RecordPushReminderDeliveryReport)->handle($event);
+
+    $report = PushReminderDeliveryReport::query()->sole();
+
+    expect($report->push_reminder_delivery_id)->toBe($delivery->id)
+        ->and($report->push_subscription_id)->toBe($subscriptionId)
+        ->and($report->status)->toBe(PushReminderDeliveryReport::STATUS_FAILED)
+        ->and($report->http_status)->toBe(410)
+        ->and($report->expired)->toBeTrue()
+        ->and($report->endpoint_host)->toBe('fcm.googleapis.com');
+});
+
+it('links reports by user and reminder metadata when the payload has no delivery id', function () {
+    $user = User::factory()->create();
+    $subscription = pushSubscriptionFor($user, 'https://fcm.googleapis.com/fcm/send/fallback-token');
+    $delivery = pushDeliveryFor($user);
+    $notification = new ReadingReminderPushNotification(
+        $delivery->reminder_type,
+        $delivery->reminder_date->toDateString(),
+        'https://example.com/logs',
+    );
+    $message = $notification->toWebPush($user, $notification);
+    $event = new NotificationSent(
+        new MessageSentReport(
+            new Request('POST', $subscription->endpoint),
+            new Response(201, [], 'accepted'),
+        ),
+        $subscription,
+        $message,
+    );
+
+    (new RecordPushReminderDeliveryReport)->handle($event);
+
+    $report = PushReminderDeliveryReport::query()->sole();
+
+    expect($report->push_reminder_delivery_id)->toBe($delivery->id)
+        ->and($report->user_id)->toBe($user->id)
+        ->and($report->reminder_type)->toBe(PushReminderDelivery::TYPE_DAILY_READING)
+        ->and($report->reminder_date->toDateString())->toBe('2026-06-01');
+});
+
+it('includes reminder delivery metadata in the webpush payload', function () {
+    $user = User::factory()->create();
+    $delivery = pushDeliveryFor($user);
+
+    $message = reminderMessageFor($user, $delivery)->toArray();
+
+    expect($message['data']['deliveryId'])->toBe($delivery->id)
+        ->and($message['data']['reminderType'])->toBe(PushReminderDelivery::TYPE_DAILY_READING)
+        ->and($message['data']['reminderDate'])->toBe('2026-06-01');
+});
+
+function pushSubscriptionFor(User $user, string $endpoint): PushSubscription
+{
+    return $user->updatePushSubscription($endpoint, 'public-key', 'auth-token', 'aes128gcm');
+}
+
+function pushDeliveryFor(User $user): PushReminderDelivery
+{
+    return PushReminderDelivery::factory()->for($user)->create([
+        'reminder_type' => PushReminderDelivery::TYPE_DAILY_READING,
+        'reminder_date' => '2026-06-01',
+        'scheduled_for_at' => '2026-06-01 09:00:08',
+    ]);
+}
+
+function reminderMessageFor(User $user, PushReminderDelivery $delivery): WebPushMessage
+{
+    $notification = new ReadingReminderPushNotification(
+        $delivery->reminder_type,
+        $delivery->reminder_date->toDateString(),
+        'https://example.com/logs',
+        $delivery->id,
+    );
+
+    return $notification->toWebPush($user, $notification);
+}

--- a/tests/Feature/PushReminderDeliveryReportTest.php
+++ b/tests/Feature/PushReminderDeliveryReportTest.php
@@ -18,15 +18,7 @@ it('records successful webpush reports for a reminder delivery subscription', fu
     $subscription = pushSubscriptionFor($user, 'https://fcm.googleapis.com/fcm/send/success-token');
     $delivery = pushDeliveryFor($user);
 
-    $message = reminderMessageFor($user, $delivery);
-    $event = new NotificationSent(
-        new MessageSentReport(
-            new Request('POST', $subscription->endpoint),
-            new Response(201, [], 'accepted'),
-        ),
-        $subscription,
-        $message,
-    );
+    $event = sentWebPushEvent($subscription, reminderMessageFor($user, $delivery));
 
     (new RecordPushReminderDeliveryReport)->handle($event);
 
@@ -51,16 +43,12 @@ it('records failed webpush reports without deleting non-expired subscription evi
     $subscription = pushSubscriptionFor($user, 'https://fcm.googleapis.com/fcm/send/failure-token');
     $delivery = pushDeliveryFor($user);
 
-    $message = reminderMessageFor($user, $delivery);
-    $event = new NotificationFailed(
-        new MessageSentReport(
-            new Request('POST', $subscription->endpoint),
-            new Response(403, [], 'VAPID credentials rejected'),
-            false,
-            'Client error: 403 Forbidden',
-        ),
+    $event = failedWebPushEvent(
         $subscription,
-        $message,
+        reminderMessageFor($user, $delivery),
+        403,
+        'VAPID credentials rejected',
+        'Client error: 403 Forbidden',
     );
 
     (new RecordPushReminderDeliveryReport)->handle($event);
@@ -78,24 +66,44 @@ it('records failed webpush reports without deleting non-expired subscription evi
     expect($user->pushSubscriptions()->whereKey($subscription->id)->exists())->toBeTrue();
 });
 
+it('records failed webpush reports without an HTTP response', function () {
+    $user = User::factory()->create();
+    $subscription = pushSubscriptionFor($user, 'https://fcm.googleapis.com/fcm/send/transport-failure-token');
+    $delivery = pushDeliveryFor($user);
+
+    $event = failedWebPushEventWithoutResponse(
+        $subscription,
+        reminderMessageFor($user, $delivery),
+        'cURL error 28: Operation timed out',
+    );
+
+    (new RecordPushReminderDeliveryReport)->handle($event);
+
+    $report = PushReminderDeliveryReport::query()->sole();
+
+    expect($report->push_reminder_delivery_id)->toBe($delivery->id)
+        ->and($report->push_subscription_id)->toBe($subscription->id)
+        ->and($report->status)->toBe(PushReminderDeliveryReport::STATUS_FAILED)
+        ->and($report->http_status)->toBeNull()
+        ->and($report->expired)->toBeFalse()
+        ->and($report->failure_reason)->toBe('cURL error 28: Operation timed out')
+        ->and($report->response_body)->toBeNull();
+});
+
 it('records expired endpoint reports after the subscription row has already been deleted', function () {
     $user = User::factory()->create();
     $subscription = pushSubscriptionFor($user, 'https://fcm.googleapis.com/fcm/send/expired-token');
     $subscriptionId = $subscription->id;
     $delivery = pushDeliveryFor($user);
 
-    $message = reminderMessageFor($user, $delivery);
     $subscription->delete();
 
-    $event = new NotificationFailed(
-        new MessageSentReport(
-            new Request('POST', $subscription->endpoint),
-            new Response(410, [], 'push subscription expired'),
-            false,
-            'Client error: 410 Gone',
-        ),
+    $event = failedWebPushEvent(
         $subscription,
-        $message,
+        reminderMessageFor($user, $delivery),
+        410,
+        'push subscription expired',
+        'Client error: 410 Gone',
     );
 
     (new RecordPushReminderDeliveryReport)->handle($event);
@@ -119,15 +127,7 @@ it('links reports by user and reminder metadata when the payload has no delivery
         $delivery->reminder_date->toDateString(),
         'https://example.com/logs',
     );
-    $message = $notification->toWebPush($user, $notification);
-    $event = new NotificationSent(
-        new MessageSentReport(
-            new Request('POST', $subscription->endpoint),
-            new Response(201, [], 'accepted'),
-        ),
-        $subscription,
-        $message,
-    );
+    $event = sentWebPushEvent($subscription, $notification->toWebPush($user, $notification));
 
     (new RecordPushReminderDeliveryReport)->handle($event);
 
@@ -174,4 +174,52 @@ function reminderMessageFor(User $user, PushReminderDelivery $delivery): WebPush
     );
 
     return $notification->toWebPush($user, $notification);
+}
+
+function sentWebPushEvent(PushSubscription $subscription, WebPushMessage $message): NotificationSent
+{
+    return new NotificationSent(
+        new MessageSentReport(
+            new Request('POST', $subscription->endpoint),
+            new Response(201, [], 'accepted'),
+        ),
+        $subscription,
+        $message,
+    );
+}
+
+function failedWebPushEvent(
+    PushSubscription $subscription,
+    WebPushMessage $message,
+    int $httpStatus,
+    string $responseBody,
+    string $reason,
+): NotificationFailed {
+    return new NotificationFailed(
+        new MessageSentReport(
+            new Request('POST', $subscription->endpoint),
+            new Response($httpStatus, [], $responseBody),
+            false,
+            $reason,
+        ),
+        $subscription,
+        $message,
+    );
+}
+
+function failedWebPushEventWithoutResponse(
+    PushSubscription $subscription,
+    WebPushMessage $message,
+    string $reason,
+): NotificationFailed {
+    return new NotificationFailed(
+        new MessageSentReport(
+            new Request('POST', $subscription->endpoint),
+            null,
+            false,
+            $reason,
+        ),
+        $subscription,
+        $message,
+    );
 }


### PR DESCRIPTION
## Summary
- Added a persistent `push_reminder_delivery_reports` table plus model/listener wiring to record each web push endpoint result for reading reminders.
- `SendReadingReminderPush` now includes the reminder delivery id in the notification payload so reports can be linked back to the originating delivery.
- The new listener records `sent`/`failed`, HTTP status, expired status, endpoint host/hash, and response diagnostics for each subscription.

## Testing
- Added Pest coverage for successful sends, failed sends, expired subscription handling, payload metadata, and fallback linkage when `deliveryId` is absent.
- Verified the focused reminder suites pass and ran Pint formatting successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Reading reminder push notifications now include delivery tracking. The system captures and reports on delivery status (sent or failed), endpoint details, HTTP responses, and failure reasons for improved notification reliability monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->