### PR TITLE
[DEL-265] Always allow yesterday logging 

### DIFF
--- a/app/Http/Controllers/ReadingLogController.php
+++ b/app/Http/Controllers/ReadingLogController.php
@@ -47,7 +47,7 @@ class ReadingLogController extends Controller
         // Pass empty error bag for consistent template behavior
         $errors = new MessageBag;
 
-        // Get form context data (yesterday logic, streak info)
+        // Get form context data
         $formContext = $this->readingFormService->getFormContextData($request->user());
 
         $data = array_merge(compact('books', 'errors'), $formContext);
@@ -155,12 +155,13 @@ class ReadingLogController extends Controller
             // Pass errors directly to the view
             $errors = new MessageBag($e->errors());
 
-            // Get form context data (yesterday logic, streak info)
+            // Get form context data
             $formContext = $this->readingFormService->getFormContextData($request->user());
+            $selectedDateRead = $this->selectedDateReadForForm($request);
 
             // Return appropriate fragment or view based on request type
             return response()->htmx('logs.create', 'reading-form', array_merge(
-                compact('books', 'errors'),
+                compact('books', 'errors', 'selectedDateRead'),
                 $formContext
             ));
         } catch (InvalidArgumentException $e) {
@@ -171,12 +172,13 @@ class ReadingLogController extends Controller
             // Create error bag for form display
             $errors = new MessageBag(['start_chapter' => [$e->getMessage()]]);
 
-            // Get form context data (yesterday logic, streak info)
+            // Get form context data
             $formContext = $this->readingFormService->getFormContextData($request->user());
+            $selectedDateRead = $this->selectedDateReadForForm($request);
 
             // Return appropriate fragment or view based on request type
             return response()->htmx('logs.create', 'reading-form', array_merge(
-                compact('books', 'errors'),
+                compact('books', 'errors', 'selectedDateRead'),
                 $formContext
             ));
         } catch (QueryException $e) {
@@ -190,12 +192,13 @@ class ReadingLogController extends Controller
                 $dateLabel = $request->input('date_read') === $yesterday ? 'yesterday' : 'today';
                 $errors = new MessageBag(['start_chapter' => ["You have already logged one or more of these chapters for {$dateLabel}."]]);
 
-                // Get form context data (yesterday logic, streak info)
+                // Get form context data
                 $formContext = $this->readingFormService->getFormContextData($request->user());
+                $selectedDateRead = $this->selectedDateReadForForm($request);
 
                 // Return appropriate fragment or view based on request type
                 return response()->htmx('logs.create', 'reading-form', array_merge(
-                    compact('books', 'errors'),
+                    compact('books', 'errors', 'selectedDateRead'),
                     $formContext
                 ));
             }
@@ -216,6 +219,15 @@ class ReadingLogController extends Controller
         return view('components.celebrations.achievement-unlocks', [
             'payload' => $payload,
         ])->render();
+    }
+
+    private function selectedDateReadForForm(Request $request): string
+    {
+        $yesterday = today()->subDay()->toDateString();
+
+        return $request->input('date_read') === $yesterday
+            ? $yesterday
+            : today()->toDateString();
     }
 
     /**

--- a/app/Http/Controllers/ReadingLogController.php
+++ b/app/Http/Controllers/ReadingLogController.php
@@ -187,7 +187,8 @@ class ReadingLogController extends Controller
                 $books = $this->bibleReferenceService->listBibleBooks(null, 'en', $includeDeuterocanonical);
 
                 // Create error bag for form display
-                $errors = new MessageBag(['start_chapter' => ['You have already logged one or more of these chapters for today.']]);
+                $dateLabel = $request->input('date_read') === $yesterday ? 'yesterday' : 'today';
+                $errors = new MessageBag(['start_chapter' => ["You have already logged one or more of these chapters for {$dateLabel}."]]);
 
                 // Get form context data (yesterday logic, streak info)
                 $formContext = $this->readingFormService->getFormContextData($request->user());

--- a/app/Services/ReadingFormService.php
+++ b/app/Services/ReadingFormService.php
@@ -6,10 +6,6 @@ use App\Models\User;
 
 class ReadingFormService
 {
-    public function __construct(
-        private ReadingLogService $readingLogService
-    ) {}
-
     /**
      * Check if the user has read today.
      */
@@ -21,31 +17,13 @@ class ReadingFormService
     }
 
     /**
-     * Get yesterday availability logic and user reading status for the form.
+     * Get yesterday availability logic for the form.
      * Yesterday is always available for missed-log recovery.
      */
     public function getFormContextData(User $user): array
     {
-        $hasReadToday = $this->hasReadToday($user);
-
-        $hasReadYesterday = $user->readingLogs()
-            ->whereDate('date_read', today()->subDay())
-            ->exists();
-
-        $hasReadingTwoDaysAgo = $user->readingLogs()
-            ->whereDate('date_read', today()->subDays(2))
-            ->exists();
-
-        $currentStreak = $this->readingLogService->calculateCurrentStreak($user);
-
-        $allowYesterday = true;
-
         return [
-            'allowYesterday' => $allowYesterday,
-            'hasReadToday' => $hasReadToday,
-            'hasReadYesterday' => $hasReadYesterday,
-            'hasReadingTwoDaysAgo' => $hasReadingTwoDaysAgo,
-            'currentStreak' => $currentStreak,
+            'allowYesterday' => true,
         ];
     }
 }

--- a/app/Services/ReadingFormService.php
+++ b/app/Services/ReadingFormService.php
@@ -22,7 +22,7 @@ class ReadingFormService
 
     /**
      * Get yesterday availability logic and user reading status for the form.
-     * This determines if the "yesterday" option should be available based on streak preservation.
+     * Yesterday is always available for missed-log recovery.
      */
     public function getFormContextData(User $user): array
     {
@@ -38,12 +38,7 @@ class ReadingFormService
 
         $currentStreak = $this->readingLogService->calculateCurrentStreak($user);
 
-        // Check if user is new (created today) to prevent logging for yesterday before they existed
-        $isNewUser = $user->created_at->isToday();
-
-        // Only surface yesterday when it can repair the active streak bridge between
-        // today and the day before yesterday. Otherwise the date choice adds noise.
-        $allowYesterday = ! $hasReadYesterday && ! $isNewUser && $hasReadingTwoDaysAgo;
+        $allowYesterday = true;
 
         return [
             'allowYesterday' => $allowYesterday,

--- a/resources/views/logs/create.blade.php
+++ b/resources/views/logs/create.blade.php
@@ -55,24 +55,10 @@
                             <fieldset class="space-y-2">
                                 <legend class="text-sm font-medium text-gray-700 dark:text-gray-300">When did you read?</legend>
 
-                                <div class="grid grid-cols-2 gap-2">
-                                    <div class="flex items-center">
-                                        <input
-                                            type="radio"
-                                            id="yesterday"
-                                            name="date_read"
-                                            value="{{ today()->subDay()->toDateString() }}"
-                                            {{ old('date_read') == today()->subDay()->toDateString() ? 'checked' : '' }}
-                                            class="peer sr-only"
-                                        >
-                                        <label
-                                            for="yesterday"
-                                            class="flex w-full cursor-pointer items-center justify-center rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-50 peer-checked:border-primary-600 peer-checked:bg-primary-50 peer-checked:text-primary-700 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600 dark:peer-checked:border-primary-500 dark:peer-checked:bg-primary-900/30 dark:peer-checked:text-primary-300"
-                                        >
-                                            Yesterday
-                                        </label>
-                                    </div>
-
+                                <div
+                                    data-date-read-segmented-control
+                                    class="grid grid-cols-2 overflow-hidden rounded-lg border border-gray-300 bg-white shadow-sm dark:border-gray-600 dark:bg-gray-700"
+                                >
                                     <div class="flex items-center">
                                         <input
                                             type="radio"
@@ -84,14 +70,31 @@
                                         >
                                         <label
                                             for="today"
-                                            class="flex w-full cursor-pointer items-center justify-center rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-50 peer-checked:border-primary-600 peer-checked:bg-primary-50 peer-checked:text-primary-700 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600 dark:peer-checked:border-primary-500 dark:peer-checked:bg-primary-900/30 dark:peer-checked:text-primary-300"
+                                            class="flex w-full cursor-pointer items-center justify-center bg-transparent px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 peer-checked:bg-primary-50 peer-checked:text-primary-700 peer-checked:hover:bg-primary-50 peer-focus-visible:relative peer-focus-visible:z-10 peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-primary-500 peer-focus-visible:ring-inset dark:text-gray-200 dark:hover:bg-gray-600 dark:peer-checked:bg-primary-900/30 dark:peer-checked:text-primary-300 dark:peer-checked:hover:bg-primary-900/30"
                                         >
                                             Today
                                         </label>
                                     </div>
+
+                                    <div class="flex items-center border-l border-gray-300 dark:border-gray-600">
+                                        <input
+                                            type="radio"
+                                            id="yesterday"
+                                            name="date_read"
+                                            value="{{ today()->subDay()->toDateString() }}"
+                                            {{ old('date_read') == today()->subDay()->toDateString() ? 'checked' : '' }}
+                                            class="peer sr-only"
+                                        >
+                                        <label
+                                            for="yesterday"
+                                            class="flex w-full cursor-pointer items-center justify-center bg-transparent px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 peer-checked:bg-primary-50 peer-checked:text-primary-700 peer-checked:hover:bg-primary-50 peer-focus-visible:relative peer-focus-visible:z-10 peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-primary-500 peer-focus-visible:ring-inset dark:text-gray-200 dark:hover:bg-gray-600 dark:peer-checked:bg-primary-900/30 dark:peer-checked:text-primary-300 dark:peer-checked:hover:bg-primary-900/30"
+                                        >
+                                            Yesterday
+                                        </label>
+                                    </div>
                                 </div>
 
-                                <p class="text-xs text-gray-500 dark:text-gray-400">Catch-up is available for yesterday.</p>
+                                <p class="text-xs text-gray-500 dark:text-gray-400">Forgot to log? Choose yesterday.</p>
                             </fieldset>
                         @else
                             <div class="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
@@ -113,7 +116,7 @@
                                         x-transition
                                         class="fixed left-4 right-4 top-44 z-50 w-auto rounded-lg border border-gray-200 bg-white p-3 text-xs leading-5 text-gray-600 shadow-lg dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 sm:absolute sm:left-0 sm:right-auto sm:top-7 sm:w-64"
                                     >
-                                        You can catch up on yesterday when it helps preserve a recent reading streak.
+                                        Forgot to log? Choose yesterday.
                                     </div>
                                 </div>
                             </div>

--- a/resources/views/logs/create.blade.php
+++ b/resources/views/logs/create.blade.php
@@ -50,77 +50,52 @@
                         x-init="init()"
                     >
                         @csrf
+                        @php($selectedDateRead = $selectedDateRead ?? today()->toDateString())
 
-                        @if (isset($allowYesterday) && $allowYesterday)
-                            <fieldset class="space-y-2">
-                                <legend class="text-sm font-medium text-gray-700 dark:text-gray-300">When did you read?</legend>
+                        <fieldset class="space-y-2">
+                            <legend class="text-sm font-medium text-gray-700 dark:text-gray-300">When did you read?</legend>
 
-                                <div
-                                    data-date-read-segmented-control
-                                    class="grid grid-cols-2 overflow-hidden rounded-lg border border-gray-300 bg-white shadow-sm dark:border-gray-600 dark:bg-gray-700"
-                                >
-                                    <div class="flex items-center">
-                                        <input
-                                            type="radio"
-                                            id="today"
-                                            name="date_read"
-                                            value="{{ today()->toDateString() }}"
-                                            {{ old('date_read', today()->toDateString()) == today()->toDateString() ? 'checked' : '' }}
-                                            class="peer sr-only"
-                                        >
-                                        <label
-                                            for="today"
-                                            class="flex w-full cursor-pointer items-center justify-center bg-transparent px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 peer-checked:bg-primary-50 peer-checked:text-primary-700 peer-checked:hover:bg-primary-50 peer-focus-visible:relative peer-focus-visible:z-10 peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-primary-500 peer-focus-visible:ring-inset dark:text-gray-200 dark:hover:bg-gray-600 dark:peer-checked:bg-primary-900/30 dark:peer-checked:text-primary-300 dark:peer-checked:hover:bg-primary-900/30"
-                                        >
-                                            Today
-                                        </label>
-                                    </div>
-
-                                    <div class="flex items-center border-l border-gray-300 dark:border-gray-600">
-                                        <input
-                                            type="radio"
-                                            id="yesterday"
-                                            name="date_read"
-                                            value="{{ today()->subDay()->toDateString() }}"
-                                            {{ old('date_read') == today()->subDay()->toDateString() ? 'checked' : '' }}
-                                            class="peer sr-only"
-                                        >
-                                        <label
-                                            for="yesterday"
-                                            class="flex w-full cursor-pointer items-center justify-center bg-transparent px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 peer-checked:bg-primary-50 peer-checked:text-primary-700 peer-checked:hover:bg-primary-50 peer-focus-visible:relative peer-focus-visible:z-10 peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-primary-500 peer-focus-visible:ring-inset dark:text-gray-200 dark:hover:bg-gray-600 dark:peer-checked:bg-primary-900/30 dark:peer-checked:text-primary-300 dark:peer-checked:hover:bg-primary-900/30"
-                                        >
-                                            Yesterday
-                                        </label>
-                                    </div>
+                            <div
+                                data-date-read-segmented-control
+                                class="grid grid-cols-2 overflow-hidden rounded-lg border border-gray-300 bg-white shadow-sm dark:border-gray-600 dark:bg-gray-700"
+                            >
+                                <div class="flex items-center">
+                                    <input
+                                        type="radio"
+                                        id="today"
+                                        name="date_read"
+                                        value="{{ today()->toDateString() }}"
+                                        {{ $selectedDateRead === today()->toDateString() ? 'checked' : '' }}
+                                        class="peer sr-only"
+                                    >
+                                    <label
+                                        for="today"
+                                        class="flex w-full cursor-pointer items-center justify-center bg-transparent px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 peer-checked:bg-primary-50 peer-checked:text-primary-700 peer-checked:hover:bg-primary-50 peer-focus-visible:relative peer-focus-visible:z-10 peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-primary-500 peer-focus-visible:ring-inset dark:text-gray-200 dark:hover:bg-gray-600 dark:peer-checked:bg-primary-900/30 dark:peer-checked:text-primary-300 dark:peer-checked:hover:bg-primary-900/30"
+                                    >
+                                        Today
+                                    </label>
                                 </div>
 
-                                <p class="text-xs text-gray-500 dark:text-gray-400">Forgot to log? Choose yesterday.</p>
-                            </fieldset>
-                        @else
-                            <div class="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
-                                <input type="hidden" name="date_read" value="{{ today()->toDateString() }}">
-                                <span>Logging for today, {{ today()->format('M j') }}</span>
-
-                                <div class="relative" @mouseenter="graceHelpOpen = true" @mouseleave="graceHelpOpen = false">
-                                    <button
-                                        type="button"
-                                        @click="graceHelpOpen = ! graceHelpOpen"
-                                        class="inline-flex h-5 w-5 items-center justify-center rounded-full bg-gray-100 text-xs font-semibold text-gray-500 transition hover:bg-gray-200 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
-                                        aria-label="Grace period help"
+                                <div class="flex items-center border-l border-gray-300 dark:border-gray-600">
+                                    <input
+                                        type="radio"
+                                        id="yesterday"
+                                        name="date_read"
+                                        value="{{ today()->subDay()->toDateString() }}"
+                                        {{ $selectedDateRead === today()->subDay()->toDateString() ? 'checked' : '' }}
+                                        class="peer sr-only"
                                     >
-                                        ?
-                                    </button>
-                                    <div
-                                        x-cloak
-                                        x-show="graceHelpOpen"
-                                        x-transition
-                                        class="fixed left-4 right-4 top-44 z-50 w-auto rounded-lg border border-gray-200 bg-white p-3 text-xs leading-5 text-gray-600 shadow-lg dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 sm:absolute sm:left-0 sm:right-auto sm:top-7 sm:w-64"
+                                    <label
+                                        for="yesterday"
+                                        class="flex w-full cursor-pointer items-center justify-center bg-transparent px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 peer-checked:bg-primary-50 peer-checked:text-primary-700 peer-checked:hover:bg-primary-50 peer-focus-visible:relative peer-focus-visible:z-10 peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-primary-500 peer-focus-visible:ring-inset dark:text-gray-200 dark:hover:bg-gray-600 dark:peer-checked:bg-primary-900/30 dark:peer-checked:text-primary-300 dark:peer-checked:hover:bg-primary-900/30"
                                     >
-                                        Forgot to log? Choose yesterday.
-                                    </div>
+                                        Yesterday
+                                    </label>
                                 </div>
                             </div>
-                        @endif
+
+                            <p class="text-xs text-gray-500 dark:text-gray-400">Forgot to log? Choose yesterday.</p>
+                        </fieldset>
 
                         <div class="space-y-2">
                             <label for="book_id" class="form-label">

--- a/tests/Feature/NavigationTest.php
+++ b/tests/Feature/NavigationTest.php
@@ -260,6 +260,8 @@ describe('Navigation Routes', function () {
         $response->assertSeeText('Today');
         $response->assertSeeText('Forgot to log? Choose yesterday.');
         $response->assertSee('data-date-read-segmented-control', false);
+        $response->assertDontSee('Logging for today', false);
+        $response->assertDontSee('Grace period help', false);
         $this->assertMatchesRegularExpression('/for="today".*?Today.*?for="yesterday".*?Yesterday/s', $response->getContent());
         $this->assertMatchesRegularExpression('/id="today".*?checked/s', $response->getContent());
         $this->assertMatchesRegularExpression('/class="[^"]*peer-checked:bg-primary-50[^"]*peer-checked:text-primary-700[^"]*peer-focus-visible:ring-2/', $response->getContent());
@@ -286,6 +288,7 @@ describe('Navigation Routes', function () {
         $response->assertSeeText('Yesterday');
         $response->assertSeeText('Today');
         $response->assertSeeText('Forgot to log? Choose yesterday.');
+        $response->assertDontSee('Logging for today', false);
     });
 
     it('navigates to reading history successfully', function () {

--- a/tests/Feature/NavigationTest.php
+++ b/tests/Feature/NavigationTest.php
@@ -247,31 +247,9 @@ describe('Navigation Routes', function () {
         $response->assertSee("Record today's Bible reading.");
     });
 
-    it('shows a compact today-only log form when yesterday catch-up is not useful', function () {
+    it('always shows today and yesterday on the log form', function () {
         $user = User::factory()->create([
             'created_at' => today()->subMonth(),
-        ]);
-
-        $response = $this->actingAs($user)->get(route('logs.create'));
-
-        $response->assertSuccessful();
-        $response->assertSeeText('Logging for today');
-        $response->assertSee('type="hidden" name="date_read"', false);
-        $response->assertDontSeeText('Grace Period');
-        $response->assertDontSeeText('Already logged');
-        $response->assertDontSeeText('Yesterday');
-    });
-
-    it('shows yesterday catch-up only when a recent streak gap can be repaired', function () {
-        $user = User::factory()->create([
-            'created_at' => today()->subMonth(),
-        ]);
-
-        ReadingLog::factory()->create([
-            'user_id' => $user->id,
-            'book_id' => 1,
-            'chapter' => 1,
-            'date_read' => today()->subDays(2)->toDateString(),
         ]);
 
         $response = $this->actingAs($user)->get(route('logs.create'));
@@ -280,7 +258,34 @@ describe('Navigation Routes', function () {
         $response->assertSeeText('When did you read?');
         $response->assertSeeText('Yesterday');
         $response->assertSeeText('Today');
-        $response->assertSeeText('Catch-up is available for yesterday.');
+        $response->assertSeeText('Forgot to log? Choose yesterday.');
+        $response->assertSee('data-date-read-segmented-control', false);
+        $this->assertMatchesRegularExpression('/for="today".*?Today.*?for="yesterday".*?Yesterday/s', $response->getContent());
+        $this->assertMatchesRegularExpression('/id="today".*?checked/s', $response->getContent());
+        $this->assertMatchesRegularExpression('/class="[^"]*peer-checked:bg-primary-50[^"]*peer-checked:text-primary-700[^"]*peer-focus-visible:ring-2/', $response->getContent());
+        $response->assertDontSee('peer-checked:ring-1', false);
+        $response->assertDontSee('peer-checked:ring-primary-500', false);
+    });
+
+    it('keeps yesterday available when yesterday is already logged', function () {
+        $user = User::factory()->create([
+            'created_at' => today()->subMonth(),
+        ]);
+
+        ReadingLog::factory()->create([
+            'user_id' => $user->id,
+            'book_id' => 1,
+            'chapter' => 1,
+            'date_read' => today()->subDay()->toDateString(),
+        ]);
+
+        $response = $this->actingAs($user)->get(route('logs.create'));
+
+        $response->assertSuccessful();
+        $response->assertSeeText('When did you read?');
+        $response->assertSeeText('Yesterday');
+        $response->assertSeeText('Today');
+        $response->assertSeeText('Forgot to log? Choose yesterday.');
     });
 
     it('navigates to reading history successfully', function () {

--- a/tests/Feature/ReadingLogChapterInputTest.php
+++ b/tests/Feature/ReadingLogChapterInputTest.php
@@ -92,6 +92,33 @@ class ReadingLogChapterInputTest extends TestCase
         $this->assertEquals(today()->subDay()->toDateString(), $additionalLog->date_read->toDateString());
     }
 
+    public function test_duplicate_chapter_for_yesterday_displays_the_correct_error(): void
+    {
+        $user = User::factory()->create();
+
+        $user->readingLogs()->create([
+            'book_id' => 1,
+            'chapter' => 1,
+            'passage_text' => 'Genesis 1',
+            'date_read' => today()->subDay()->toDateString(),
+        ]);
+
+        $response = $this->actingAs($user)->post('/logs', [
+            'book_id' => 1,
+            'start_chapter' => '1',
+            'date_read' => today()->subDay()->toDateString(),
+        ]);
+
+        $response->assertViewHas('errors');
+        $errors = $response->viewData('errors');
+
+        $this->assertEquals(
+            'You have already logged one or more of these chapters for yesterday.',
+            $errors->first('start_chapter')
+        );
+        $this->assertDatabaseCount('reading_logs', 1);
+    }
+
     public function test_reading_cannot_be_logged_before_yesterday(): void
     {
         $user = User::factory()->create();

--- a/tests/Feature/ReadingLogChapterInputTest.php
+++ b/tests/Feature/ReadingLogChapterInputTest.php
@@ -116,7 +116,29 @@ class ReadingLogChapterInputTest extends TestCase
             'You have already logged one or more of these chapters for yesterday.',
             $errors->first('start_chapter')
         );
+        $this->assertMatchesRegularExpression('/<input[^>]+id="yesterday"[^>]+checked/s', $response->getContent());
+        $this->assertDoesNotMatchRegularExpression('/<input[^>]+id="today"[^>]+checked/s', $response->getContent());
         $this->assertDatabaseCount('reading_logs', 1);
+    }
+
+    public function test_yesterday_selection_is_preserved_when_validation_fails(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post('/logs', [
+            'book_id' => 1,
+            'start_chapter' => '3',
+            'end_chapter' => '2',
+            'date_read' => today()->subDay()->toDateString(),
+        ]);
+
+        $response->assertViewHas('errors');
+        $errors = $response->viewData('errors');
+
+        $this->assertTrue($errors->has('start_chapter'));
+        $this->assertMatchesRegularExpression('/<input[^>]+id="yesterday"[^>]+checked/s', $response->getContent());
+        $this->assertDoesNotMatchRegularExpression('/<input[^>]+id="today"[^>]+checked/s', $response->getContent());
+        $this->assertDatabaseCount('reading_logs', 0);
     }
 
     public function test_reading_cannot_be_logged_before_yesterday(): void

--- a/tests/Feature/ReadingLogChapterInputTest.php
+++ b/tests/Feature/ReadingLogChapterInputTest.php
@@ -63,6 +63,51 @@ class ReadingLogChapterInputTest extends TestCase
         ]);
     }
 
+    public function test_additional_chapter_can_be_logged_for_yesterday(): void
+    {
+        $user = User::factory()->create();
+
+        $user->readingLogs()->create([
+            'book_id' => 1,
+            'chapter' => 1,
+            'passage_text' => 'Genesis 1',
+            'date_read' => today()->subDay()->toDateString(),
+        ]);
+
+        $response = $this->actingAs($user)->post('/logs', [
+            'book_id' => 1,
+            'start_chapter' => '2',
+            'date_read' => today()->subDay()->toDateString(),
+        ]);
+
+        $response->assertSuccessful();
+        $this->assertDatabaseHas('reading_logs', [
+            'user_id' => $user->id,
+            'book_id' => 1,
+            'chapter' => 2,
+        ]);
+
+        $additionalLog = $user->readingLogs()->where('chapter', 2)->firstOrFail();
+
+        $this->assertEquals(today()->subDay()->toDateString(), $additionalLog->date_read->toDateString());
+    }
+
+    public function test_reading_cannot_be_logged_before_yesterday(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post('/logs', [
+            'book_id' => 1,
+            'start_chapter' => '1',
+            'date_read' => today()->subDays(2)->toDateString(),
+        ]);
+
+        $response->assertViewHas('errors');
+        $errors = $response->viewData('errors');
+        $this->assertTrue($errors->has('date_read'));
+        $this->assertDatabaseCount('reading_logs', 0);
+    }
+
     /**
      * Test that explicit range input creates multiple log entries.
      */

--- a/tests/Unit/ReadingFormServiceTest.php
+++ b/tests/Unit/ReadingFormServiceTest.php
@@ -5,8 +5,8 @@ namespace Tests\Unit;
 use App\Models\ReadingLog;
 use App\Models\User;
 use App\Services\ReadingFormService;
-use App\Services\ReadingLogService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
 class ReadingFormServiceTest extends TestCase
@@ -21,8 +21,7 @@ class ReadingFormServiceTest extends TestCase
     {
         parent::setUp();
 
-        $readingLogService = $this->app->make(ReadingLogService::class);
-        $this->service = new ReadingFormService($readingLogService);
+        $this->service = new ReadingFormService;
         $this->user = User::factory()->create();
     }
 
@@ -136,10 +135,7 @@ class ReadingFormServiceTest extends TestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * Test that getFormContextData uses the hasReadToday method
-     */
-    public function test_get_form_context_data_uses_has_read_today_method(): void
+    public function test_get_form_context_data_excludes_unused_read_status(): void
     {
         // Create a reading log for today
         ReadingLog::factory()->create([
@@ -151,14 +147,8 @@ class ReadingFormServiceTest extends TestCase
 
         $contextData = $this->service->getFormContextData($this->user);
 
-        // Verify that hasReadToday is true in the context data
-        $this->assertTrue($contextData['hasReadToday']);
-
-        // Verify the method returns the same result as calling hasReadToday directly
-        $this->assertEquals(
-            $this->service->hasReadToday($this->user),
-            $contextData['hasReadToday']
-        );
+        $this->assertTrue($this->service->hasReadToday($this->user));
+        $this->assertArrayNotHasKey('hasReadToday', $contextData);
     }
 
     public function test_get_form_context_data_allows_yesterday_without_a_recent_streak(): void
@@ -170,7 +160,6 @@ class ReadingFormServiceTest extends TestCase
         $contextData = $this->service->getFormContextData($this->user);
 
         $this->assertTrue($contextData['allowYesterday']);
-        $this->assertFalse($contextData['hasReadingTwoDaysAgo']);
     }
 
     public function test_get_form_context_data_allows_yesterday_for_a_new_user(): void
@@ -196,7 +185,6 @@ class ReadingFormServiceTest extends TestCase
         $contextData = $this->service->getFormContextData($this->user);
 
         $this->assertTrue($contextData['allowYesterday']);
-        $this->assertTrue($contextData['hasReadingTwoDaysAgo']);
     }
 
     public function test_get_form_context_data_allows_yesterday_when_yesterday_is_already_logged(): void
@@ -217,6 +205,22 @@ class ReadingFormServiceTest extends TestCase
         $contextData = $this->service->getFormContextData($this->user);
 
         $this->assertTrue($contextData['allowYesterday']);
-        $this->assertTrue($contextData['hasReadYesterday']);
+    }
+
+    public function test_get_form_context_data_does_not_query_unused_reading_state(): void
+    {
+        ReadingLog::factory()->create([
+            'user_id' => $this->user->id,
+            'book_id' => 1,
+            'chapter' => 1,
+            'date_read' => today()->subDay()->toDateString(),
+        ]);
+
+        DB::enableQueryLog();
+
+        $contextData = $this->service->getFormContextData($this->user);
+
+        $this->assertTrue($contextData['allowYesterday']);
+        $this->assertEmpty(DB::getQueryLog());
     }
 }

--- a/tests/Unit/ReadingFormServiceTest.php
+++ b/tests/Unit/ReadingFormServiceTest.php
@@ -161,7 +161,7 @@ class ReadingFormServiceTest extends TestCase
         );
     }
 
-    public function test_get_form_context_data_hides_yesterday_when_it_does_not_preserve_recent_streak(): void
+    public function test_get_form_context_data_allows_yesterday_without_a_recent_streak(): void
     {
         $this->user->forceFill([
             'created_at' => today()->subMonth(),
@@ -169,8 +169,15 @@ class ReadingFormServiceTest extends TestCase
 
         $contextData = $this->service->getFormContextData($this->user);
 
-        $this->assertFalse($contextData['allowYesterday']);
+        $this->assertTrue($contextData['allowYesterday']);
         $this->assertFalse($contextData['hasReadingTwoDaysAgo']);
+    }
+
+    public function test_get_form_context_data_allows_yesterday_for_a_new_user(): void
+    {
+        $contextData = $this->service->getFormContextData($this->user);
+
+        $this->assertTrue($contextData['allowYesterday']);
     }
 
     public function test_get_form_context_data_allows_yesterday_when_recent_streak_gap_can_be_caught_up(): void
@@ -192,7 +199,7 @@ class ReadingFormServiceTest extends TestCase
         $this->assertTrue($contextData['hasReadingTwoDaysAgo']);
     }
 
-    public function test_get_form_context_data_hides_yesterday_when_yesterday_is_already_logged(): void
+    public function test_get_form_context_data_allows_yesterday_when_yesterday_is_already_logged(): void
     {
         $this->user->forceFill([
             'created_at' => today()->subMonth(),
@@ -209,7 +216,7 @@ class ReadingFormServiceTest extends TestCase
 
         $contextData = $this->service->getFormContextData($this->user);
 
-        $this->assertFalse($contextData['allowYesterday']);
+        $this->assertTrue($contextData['allowYesterday']);
         $this->assertTrue($contextData['hasReadYesterday']);
     }
 }


### PR DESCRIPTION
## Summary
- Always show the today/yesterday selector on the reading log form so missed-log recovery is available without conditional hiding.
- Keep yesterday submissions allowed for additional chapters, while duplicate chapter submissions now show the correct day in the error message.
- Update the form copy and tests to reflect the always-available yesterday flow.

## Testing
- Added regression coverage for logging additional chapters for yesterday.
- Added regression coverage for duplicate yesterday submissions displaying the correct error.
- Ran focused Pest suites, `vendor/bin/pint --dirty --format agent`, and diff checks successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Yesterday" option is always offered when creating reading logs.

* **Bug Fixes**
  * Duplicate-chapter errors show the correct date label (yesterday vs today) and preserve the selected date when validation fails.

* **Style**
  * Redesigned date selection into a segmented control with the prompt: "Forgot to log? Choose yesterday."

* **Tests**
  * Updated and added tests covering yesterday behavior, duplicate-entry handling, and form context expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->