### PR TITLE
Compact reading plan detail UI

### DIFF
--- a/resources/views/plans/today.blade.php
+++ b/resources/views/plans/today.blade.php
@@ -10,23 +10,18 @@
                 <div class="max-w-2xl mx-auto sm:px-6 lg:px-8">
                     @fragment('reading-list')
                         <div id="reading-list-container">
-                                <div class="space-y-6">
+                                <div class="space-y-4 sm:space-y-6">
                             {{-- Progress Header --}}
                             <div
-                                class="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-6">
-                                <div class="flex items-center justify-between mb-4">
+                                class="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-4 sm:p-6">
+                                <div class="flex items-start justify-between mb-3 sm:mb-4">
                                     <div>
                                         <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
-                                            {{ $plan->name }}
+                                            {{ $plan->getShortName() }}
                                         </h2>
                                         <p class="text-sm text-gray-500 dark:text-gray-400">
-                                            Day {{ $day_number }} of {{ $total_days }}
+                                            Day {{ $day_number }} of {{ $total_days }}@if ($subscription->start_day > 1) · tracking from Day {{ $subscription->start_day }}@endif
                                         </p>
-                                        @if ($subscription->start_day > 1)
-                                            <p class="text-xs text-gray-500 dark:text-gray-400">
-                                                Started tracking from Day {{ $subscription->start_day }}
-                                            </p>
-                                        @endif
                                         @if ($current_day !== $day_number)
                                             <p class="text-xs text-gray-500 dark:text-gray-400">
                                                 Current day: {{ $current_day }}
@@ -56,12 +51,14 @@
                                                 hx-get="{{ route('plans.today', ['plan' => $plan, 'day' => $previous_day]) }}"
                                                 hx-target="#page-container" hx-swap="innerHTML" hx-push-url="true"
                                                 class="inline-flex items-center px-3 py-1.5 text-xs font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 dark:text-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 rounded-lg transition-colors">
-                                                Previous Day
+                                                <span class="sm:hidden">Previous</span>
+                                                <span class="hidden sm:inline">Previous Day</span>
                                             </a>
                                         @else
                                             <span
                                                 class="inline-flex items-center px-3 py-1.5 text-xs font-medium text-gray-400 bg-gray-100 dark:text-gray-500 dark:bg-gray-700 rounded-lg cursor-not-allowed">
-                                                Previous Day
+                                                <span class="sm:hidden">Previous</span>
+                                                <span class="hidden sm:inline">Previous Day</span>
                                             </span>
                                         @endif
                                         @if ($next_day !== null)
@@ -69,12 +66,14 @@
                                                 hx-get="{{ route('plans.today', ['plan' => $plan, 'day' => $next_day]) }}"
                                                 hx-target="#page-container" hx-swap="innerHTML" hx-push-url="true"
                                                 class="inline-flex items-center px-3 py-1.5 text-xs font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 dark:text-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 rounded-lg transition-colors">
-                                                Next Day
+                                                <span class="sm:hidden">Next</span>
+                                                <span class="hidden sm:inline">Next Day</span>
                                             </a>
                                         @else
                                             <span
                                                 class="inline-flex items-center px-3 py-1.5 text-xs font-medium text-gray-400 bg-gray-100 dark:text-gray-500 dark:bg-gray-700 rounded-lg cursor-not-allowed">
-                                                Next Day
+                                                <span class="sm:hidden">Next</span>
+                                                <span class="hidden sm:inline">Next Day</span>
                                             </span>
                                         @endif
                                     </div>
@@ -93,10 +92,10 @@
                                 {{-- Today's Reading Card --}}
                                 <div
                                     class="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden">
-                                    <div class="p-6">
-                                        <div class="flex items-center justify-between mb-4">
+                                    <div class="p-4 sm:p-6">
+                                        <div class="flex items-center justify-between gap-3 mb-3 sm:mb-4">
                                             <h3 class="text-lg font-semibold text-gray-900 dark:text-white">
-                                                Day {{ $day_number }} Reading
+                                                Day {{ $day_number }}<span class="hidden sm:inline"> Reading</span>
                                             </h3>
                                             @if ($is_active && !$is_before_tracking && !$reading['all_completed'])
                                                 <form hx-post="{{ route('plans.logAll', $plan) }}"
@@ -110,7 +109,8 @@
                                                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                                                                 d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
                                                         </svg>
-                                                        Mark day complete
+                                                        <span class="sm:hidden">Complete day</span>
+                                                        <span class="hidden sm:inline">Mark day complete</span>
                                                     </button>
                                                 </form>
                                             @elseif ($reading['all_completed'])
@@ -125,10 +125,6 @@
                                                 </span>
                                             @endif
                                         </div>
-
-                                        <p class="text-gray-600 dark:text-gray-400 mb-4">
-                                            {{ $reading['label'] }}
-                                        </p>
 
                                         @if ($is_before_tracking)
                                             <div class="mb-4 rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 dark:border-gray-700 dark:bg-gray-700/40">

--- a/resources/views/plans/today.blade.php
+++ b/resources/views/plans/today.blade.php
@@ -14,31 +14,29 @@
                             {{-- Progress Header --}}
                             <div
                                 class="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-4 sm:p-6">
-                                <div class="flex items-start justify-between mb-3 sm:mb-4">
-                                    <div>
-                                        <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
-                                            {{ $plan->getShortName() }}
-                                        </h2>
-                                        <p class="text-sm text-gray-500 dark:text-gray-400">
-                                            Day {{ $day_number }} of {{ $total_days }}@if ($subscription->start_day > 1) · tracking from Day {{ $subscription->start_day }}@endif
-                                        </p>
-                                        @if ($current_day !== $day_number)
-                                            <p class="text-xs text-gray-500 dark:text-gray-400">
-                                                Current day: {{ $current_day }}
-                                            </p>
-                                        @endif
-                                    </div>
+                                <div class="flex items-start justify-between gap-4">
+                                    <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
+                                        {{ $plan->getShortName() }}
+                                    </h2>
                                     <div class="text-right">
                                         <p class="text-2xl font-bold text-primary-600 dark:text-primary-400">
                                             {{ $progress }}%
-                                        </p>
-                                        <p class="text-xs text-gray-500 dark:text-gray-400">
-                                            {{ $completed_days_count }} of {{ $tracked_days_count }} tracked days complete
                                         </p>
                                         @if ($is_complete)
                                             <p class="text-xs font-medium text-green-600 dark:text-green-400">Tracking complete</p>
                                         @endif
                                     </div>
+                                </div>
+                                <div class="mb-3 sm:mb-4">
+                                    <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                                        <span class="sm:hidden">Day {{ $day_number }}/{{ $total_days }}@if ($subscription->start_day > 1) · tracking from {{ $subscription->start_day }}@endif · {{ $completed_days_count }}/{{ $tracked_days_count }} complete</span>
+                                        <span class="hidden sm:inline">Day {{ $day_number }} of {{ $total_days }}@if ($subscription->start_day > 1) · tracking from Day {{ $subscription->start_day }}@endif · {{ $completed_days_count }} of {{ $tracked_days_count }} tracked days complete</span>
+                                    </p>
+                                    @if ($current_day !== $day_number)
+                                        <p class="text-xs text-gray-500 dark:text-gray-400">
+                                            Current day: {{ $current_day }}
+                                        </p>
+                                    @endif
                                 </div>
                                 <div class="w-full bg-gray-200 rounded-full h-2 dark:bg-gray-700">
                                     <div class="bg-primary-600 h-2 rounded-full transition-all duration-500"

--- a/tests/Feature/ReadingPlanTest.php
+++ b/tests/Feature/ReadingPlanTest.php
@@ -379,8 +379,40 @@ describe("Today's Reading", function () {
             ->get(route('plans.today', $this->plan));
 
         $response->assertOk();
-        $response->assertSee('Genesis 1-3');
+        $response->assertSee('Genesis 1');
+        $response->assertSee('Genesis 3');
         $response->assertSee('Day 1');
+    });
+
+    it('renders a compact reading plan detail view', function () {
+        $plan = createTestPlan([
+            'slug' => 'compact-plan',
+            'name' => 'Compact Reading Plan',
+        ]);
+
+        ReadingPlanSubscription::create([
+            'user_id' => $this->user->id,
+            'reading_plan_id' => $plan->id,
+            'started_at' => Carbon::today(),
+            'start_day' => 2,
+            'is_active' => true,
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->get(route('plans.today', $plan));
+
+        $response->assertOk();
+        $response->assertSee('Compact');
+        $response->assertDontSee('Compact Reading Plan');
+        $response->assertSeeText('Day 2 of 2 · tracking from Day 2');
+        $response->assertDontSee('Genesis 4-6');
+        $response->assertSee('Genesis 4');
+        $response->assertSee('Genesis 5');
+        $response->assertSee('Genesis 6');
+        $response->assertSee('<span class="sm:hidden">Previous</span>', false);
+        $response->assertSee('<span class="sm:hidden">Next</span>', false);
+        $response->assertSee('<span class="sm:hidden">Complete day</span>', false);
+        $response->assertSee('class="flex items-start justify-between mb-3 sm:mb-4"', false);
     });
 
     it('keeps day 1 reading until day 1 is complete', function () {
@@ -394,7 +426,8 @@ describe("Today's Reading", function () {
             ->get(route('plans.today', $this->plan));
 
         $response->assertOk();
-        $response->assertSee('Genesis 1-3');
+        $response->assertSee('Genesis 1');
+        $response->assertSee('Genesis 3');
         $response->assertSee('Day 1');
     });
 
@@ -426,7 +459,8 @@ describe("Today's Reading", function () {
             ->get(route('plans.today', $this->plan));
 
         $response->assertOk();
-        $response->assertSee('Genesis 4-6');
+        $response->assertSee('Genesis 4');
+        $response->assertSee('Genesis 6');
         $response->assertSee('Day 2');
     });
 
@@ -441,7 +475,8 @@ describe("Today's Reading", function () {
             ->get(route('plans.today', ['plan' => $this->plan, 'day' => 2]));
 
         $response->assertOk();
-        $response->assertSee('Genesis 4-6');
+        $response->assertSee('Genesis 4');
+        $response->assertSee('Genesis 6');
         $response->assertSee('Day 2');
     });
 

--- a/tests/Feature/ReadingPlanTest.php
+++ b/tests/Feature/ReadingPlanTest.php
@@ -404,7 +404,8 @@ describe("Today's Reading", function () {
         $response->assertOk();
         $response->assertSee('Compact');
         $response->assertDontSee('Compact Reading Plan');
-        $response->assertSeeText('Day 2 of 2 · tracking from Day 2');
+        $response->assertSee('<span class="sm:hidden">Day 2/2 · tracking from 2 · 0/1 complete</span>', false);
+        $response->assertSee('<span class="hidden sm:inline">Day 2 of 2 · tracking from Day 2 · 0 of 1 tracked days complete</span>', false);
         $response->assertDontSee('Genesis 4-6');
         $response->assertSee('Genesis 4');
         $response->assertSee('Genesis 5');
@@ -412,7 +413,7 @@ describe("Today's Reading", function () {
         $response->assertSee('<span class="sm:hidden">Previous</span>', false);
         $response->assertSee('<span class="sm:hidden">Next</span>', false);
         $response->assertSee('<span class="sm:hidden">Complete day</span>', false);
-        $response->assertSee('class="flex items-start justify-between mb-3 sm:mb-4"', false);
+        $response->assertSee('class="flex items-start justify-between gap-4"', false);
     });
 
     it('keeps day 1 reading until day 1 is complete', function () {


### PR DESCRIPTION
## Problem

The reading plan detail page still used full plan names and repeated the day's passage summary directly above the actionable chapter list. On mobile, this pushed the plan navigation controls below the visible area.

## Changes

- Use the existing concise reading plan name on the detail page.
- Remove the repeated passage summary while preserving individual chapter actions.
- Tighten mobile-only card spacing and shorten mobile control labels.
- Top-align the plan title and progress percentage.
- Add focused rendering coverage and update affected reading-plan assertions.

## Verification

- `php artisan test --compact tests/Feature/ReadingPlanTest.php`
- `vendor/bin/pint --dirty --format agent`
- `git diff --check`
- Verified at a 412x915 mobile viewport in the browser; the title and percentage align at the top, and All Plans / Leave Plan are visible above the bottom navigation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Responsive navigation buttons now display "Previous/Next" on small screens and full labels on larger screens
  * "Mark day complete" button labels adapt by screen size
  * Improved reading card header spacing with responsive design elements
  * Disabled state styling for unavailable day navigation

* **Tests**
  * Enhanced test coverage for Today's Reading view functionality
  * Added new test for compact reading plan detail view

<!-- end of auto-generated comment: release notes by coderabbit.ai -->