### PR TITLE
[DEL-177] Add recent book suggestions to reading log

### DIFF
--- a/app/Http/Controllers/ReadingLogController.php
+++ b/app/Http/Controllers/ReadingLogController.php
@@ -242,11 +242,18 @@ class ReadingLogController extends Controller
     private function submittedValuesForForm(Request $request): array
     {
         return [
-            'selectedBookId' => (string) $request->input('book_id', ''),
-            'selectedStartChapter' => (string) $request->input('start_chapter', ''),
-            'selectedEndChapter' => (string) $request->input('end_chapter', ''),
-            'selectedNotesText' => (string) $request->input('notes_text', ''),
+            'selectedBookId' => $this->scalarInputForForm($request, 'book_id'),
+            'selectedStartChapter' => $this->scalarInputForForm($request, 'start_chapter'),
+            'selectedEndChapter' => $this->scalarInputForForm($request, 'end_chapter'),
+            'selectedNotesText' => $this->scalarInputForForm($request, 'notes_text'),
         ];
+    }
+
+    private function scalarInputForForm(Request $request, string $key): string
+    {
+        $value = $request->input($key, '');
+
+        return is_scalar($value) ? (string) $value : '';
     }
 
     /**

--- a/app/Http/Controllers/ReadingLogController.php
+++ b/app/Http/Controllers/ReadingLogController.php
@@ -158,10 +158,12 @@ class ReadingLogController extends Controller
             // Get form context data
             $formContext = $this->readingFormService->getFormContextData($request->user());
             $selectedDateRead = $this->selectedDateReadForForm($request);
+            $submittedFormValues = $this->submittedValuesForForm($request);
 
             // Return appropriate fragment or view based on request type
             return response()->htmx('logs.create', 'reading-form', array_merge(
                 compact('books', 'errors', 'selectedDateRead'),
+                $submittedFormValues,
                 $formContext
             ));
         } catch (InvalidArgumentException $e) {
@@ -175,10 +177,12 @@ class ReadingLogController extends Controller
             // Get form context data
             $formContext = $this->readingFormService->getFormContextData($request->user());
             $selectedDateRead = $this->selectedDateReadForForm($request);
+            $submittedFormValues = $this->submittedValuesForForm($request);
 
             // Return appropriate fragment or view based on request type
             return response()->htmx('logs.create', 'reading-form', array_merge(
                 compact('books', 'errors', 'selectedDateRead'),
+                $submittedFormValues,
                 $formContext
             ));
         } catch (QueryException $e) {
@@ -195,10 +199,12 @@ class ReadingLogController extends Controller
                 // Get form context data
                 $formContext = $this->readingFormService->getFormContextData($request->user());
                 $selectedDateRead = $this->selectedDateReadForForm($request);
+                $submittedFormValues = $this->submittedValuesForForm($request);
 
                 // Return appropriate fragment or view based on request type
                 return response()->htmx('logs.create', 'reading-form', array_merge(
                     compact('books', 'errors', 'selectedDateRead'),
+                    $submittedFormValues,
                     $formContext
                 ));
             }
@@ -228,6 +234,19 @@ class ReadingLogController extends Controller
         return $request->input('date_read') === $yesterday
             ? $yesterday
             : today()->toDateString();
+    }
+
+    /**
+     * @return array{selectedBookId:string,selectedStartChapter:string,selectedEndChapter:string,selectedNotesText:string}
+     */
+    private function submittedValuesForForm(Request $request): array
+    {
+        return [
+            'selectedBookId' => (string) $request->input('book_id', ''),
+            'selectedStartChapter' => (string) $request->input('start_chapter', ''),
+            'selectedEndChapter' => (string) $request->input('end_chapter', ''),
+            'selectedNotesText' => (string) $request->input('notes_text', ''),
+        ];
     }
 
     /**

--- a/app/Services/ReadingFormService.php
+++ b/app/Services/ReadingFormService.php
@@ -2,10 +2,19 @@
 
 namespace App\Services;
 
+use App\Models\ReadingLog;
 use App\Models\User;
 
 class ReadingFormService
 {
+    private const RECENT_BOOK_LIMIT = 3;
+
+    public function __construct(
+        private ?BibleReferenceService $bibleReferenceService = null
+    ) {
+        $this->bibleReferenceService ??= new BibleReferenceService;
+    }
+
     /**
      * Check if the user has read today.
      */
@@ -24,6 +33,45 @@ class ReadingFormService
     {
         return [
             'allowYesterday' => true,
+            'recentBooks' => $this->getRecentBooksForForm($user),
         ];
+    }
+
+    /**
+     * Get the user's recent distinct books for the reading form.
+     *
+     * @return array<int, array{id:int,name:string,chapters:int,testament:string}>
+     */
+    public function getRecentBooksForForm(User $user): array
+    {
+        $books = collect($this->bibleReferenceService->listBibleBooks(
+            includeDeuterocanonical: $user->includesDeuterocanonicalBooks()
+        ))->keyBy('id');
+
+        if ($books->isEmpty()) {
+            return [];
+        }
+
+        $rankedReadings = ReadingLog::query()
+            ->select(['book_id', 'date_read', 'created_at', 'id'])
+            ->selectRaw('ROW_NUMBER() OVER (PARTITION BY book_id ORDER BY date_read DESC, created_at DESC, id DESC) AS book_rank')
+            ->where('user_id', $user->id)
+            ->whereIn('book_id', $books->keys()->all());
+
+        $recentBookIds = ReadingLog::query()
+            ->fromSub($rankedReadings, 'ranked_reading_logs')
+            ->where('book_rank', 1)
+            ->orderByDesc('date_read')
+            ->orderByDesc('created_at')
+            ->orderByDesc('id')
+            ->limit(self::RECENT_BOOK_LIMIT)
+            ->pluck('book_id')
+            ->map(fn ($bookId) => (int) $bookId);
+
+        return $recentBookIds
+            ->map(fn (int $bookId) => $books->get($bookId))
+            ->filter()
+            ->values()
+            ->all();
     }
 }

--- a/app/Services/ReadingFormService.php
+++ b/app/Services/ReadingFormService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Models\ReadingLog;
 use App\Models\User;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 
 class ReadingFormService
 {
@@ -50,15 +51,12 @@ class ReadingFormService
             return [];
         }
 
-        $rankedReadings = ReadingLog::query()
-            ->select(['book_id', 'date_read', 'created_at', 'id'])
-            ->selectRaw('ROW_NUMBER() OVER (PARTITION BY book_id ORDER BY date_read DESC, created_at DESC, id DESC) AS book_rank')
-            ->where('user_id', $user->id)
-            ->whereIn('book_id', $books->keys()->all());
-
         $recentBookIds = ReadingLog::query()
-            ->fromSub($rankedReadings, 'ranked_reading_logs')
-            ->where('book_rank', 1)
+            ->where('user_id', $user->id)
+            ->whereIn('book_id', $books->keys()->all())
+            ->whereNotExists(function (QueryBuilder $query): void {
+                $this->constrainNewerReadingForSameBookSubquery($query);
+            })
             ->orderByDesc('date_read')
             ->orderByDesc('created_at')
             ->orderByDesc('id')
@@ -71,5 +69,25 @@ class ReadingFormService
             ->filter()
             ->values()
             ->all();
+    }
+
+    private function constrainNewerReadingForSameBookSubquery(QueryBuilder $query): void
+    {
+        $query->select('newer_reading_logs.id')
+            ->from('reading_logs as newer_reading_logs')
+            ->whereColumn('newer_reading_logs.user_id', 'reading_logs.user_id')
+            ->whereColumn('newer_reading_logs.book_id', 'reading_logs.book_id')
+            ->where(function (QueryBuilder $query): void {
+                $query->whereColumn('newer_reading_logs.date_read', '>', 'reading_logs.date_read')
+                    ->orWhere(function (QueryBuilder $query): void {
+                        $query->whereColumn('newer_reading_logs.date_read', 'reading_logs.date_read')
+                            ->whereColumn('newer_reading_logs.created_at', '>', 'reading_logs.created_at');
+                    })
+                    ->orWhere(function (QueryBuilder $query): void {
+                        $query->whereColumn('newer_reading_logs.date_read', 'reading_logs.date_read')
+                            ->whereColumn('newer_reading_logs.created_at', 'reading_logs.created_at')
+                            ->whereColumn('newer_reading_logs.id', '>', 'reading_logs.id');
+                    });
+            });
     }
 }

--- a/app/Services/ReadingFormService.php
+++ b/app/Services/ReadingFormService.php
@@ -10,10 +10,8 @@ class ReadingFormService
     private const RECENT_BOOK_LIMIT = 3;
 
     public function __construct(
-        private ?BibleReferenceService $bibleReferenceService = null
-    ) {
-        $this->bibleReferenceService ??= new BibleReferenceService;
-    }
+        private BibleReferenceService $bibleReferenceService
+    ) {}
 
     /**
      * Check if the user has read today.

--- a/resources/views/layouts/authenticated.blade.php
+++ b/resources/views/layouts/authenticated.blade.php
@@ -68,7 +68,7 @@
         </div>
 
         <!-- Main Content -->
-        <div class="flex-1 flex flex-col lg:overflow-hidden lg:pt-16">
+        <div class="min-w-0 flex-1 flex flex-col lg:overflow-hidden lg:pt-16">
             <!-- Mobile: Navbar (scrolls with content) -->
             <x-navigation.mobile-navbar class="lg:hidden" />
 

--- a/resources/views/logs/create.blade.php
+++ b/resources/views/logs/create.blade.php
@@ -187,7 +187,7 @@
                             </div>
 
                             @if ($recentBooks->isNotEmpty())
-                                <div data-recent-books class="flex max-w-full items-center gap-2 overflow-x-auto pb-1 [-webkit-overflow-scrolling:touch]">
+                                <div data-recent-books class="flex max-w-full items-center gap-2 overflow-x-auto pb-1 [-webkit-overflow-scrolling:touch] ![scrollbar-width:none] [&::-webkit-scrollbar]:!hidden">
                                     <p id="recent-books-label" class="shrink-0 text-xs font-medium text-gray-500 dark:text-gray-400">
                                         Recent
                                     </p>

--- a/resources/views/logs/create.blade.php
+++ b/resources/views/logs/create.blade.php
@@ -17,19 +17,23 @@
                         $oldTestament = collect($books)->where('testament', 'old')->values();
                         $newTestament = collect($books)->where('testament', 'new')->values();
                         $deuterocanonicalBooks = collect($books)->where('testament', 'deuterocanonical')->values();
+                        $recentBooks = collect($recentBooks ?? [])->values();
 
                         $initialTestament = 'old';
-                        $oldBookId = old('book_id');
+                        $selectedBookId = (string) ($selectedBookId ?? old('book_id', ''));
+                        $selectedStartChapter = (string) ($selectedStartChapter ?? old('start_chapter', ''));
+                        $selectedEndChapter = (string) ($selectedEndChapter ?? old('end_chapter', ''));
+                        $selectedNotesText = (string) ($selectedNotesText ?? old('notes_text', ''));
 
-                        if ($oldBookId) {
-                            if ($newTestament->firstWhere('id', $oldBookId)) {
+                        if ($selectedBookId !== '') {
+                            if ($newTestament->firstWhere('id', (int) $selectedBookId)) {
                                 $initialTestament = 'new';
-                            } elseif ($deuterocanonicalBooks->firstWhere('id', $oldBookId)) {
+                            } elseif ($deuterocanonicalBooks->firstWhere('id', (int) $selectedBookId)) {
                                 $initialTestament = 'deuterocanonical';
                             }
                         }
 
-                        $notesExpanded = filled(old('notes_text')) || (bool) $errors->first('notes_text');
+                        $notesExpanded = filled($selectedNotesText) || (bool) $errors->first('notes_text');
                     @endphp
 
                     <form
@@ -38,19 +42,22 @@
                         hx-swap="outerHTML"
                         class="space-y-6"
                         x-data="readingLogForm({
-                            initialTestament: '{{ $initialTestament }}',
-                            initialBookId: '{{ old('book_id') }}',
+                            initialTestament: @js($initialTestament),
+                            initialBookId: @js($selectedBookId),
                             initialNotesOpen: @js($notesExpanded),
+                            recentBooks: @js($recentBooks),
                             books: {
-                                old: {{ $oldTestament->toJson() }},
-                                new: {{ $newTestament->toJson() }},
-                                deuterocanonical: {{ $deuterocanonicalBooks->toJson() }}
+                                old: @js($oldTestament),
+                                new: @js($newTestament),
+                                deuterocanonical: @js($deuterocanonicalBooks)
                             }
                         })"
                         x-init="init()"
                     >
                         @csrf
-                        @php($selectedDateRead = $selectedDateRead ?? today()->toDateString())
+                        @php
+                            $selectedDateRead = $selectedDateRead ?? today()->toDateString();
+                        @endphp
 
                         <fieldset class="space-y-2">
                             <legend class="text-sm font-medium text-gray-700 dark:text-gray-300">When did you read?</legend>
@@ -97,9 +104,9 @@
                             <p class="text-xs text-gray-500 dark:text-gray-400">Forgot to log? Choose yesterday.</p>
                         </fieldset>
 
-                        <div class="space-y-2">
+                        <div class="space-y-3">
                             <label for="book_id" class="form-label">
-                                📚 Bible Book
+                                Bible book
                             </label>
 
                             <div class="relative flex">
@@ -179,6 +186,40 @@
                                 </div>
                             </div>
 
+                            @if ($recentBooks->isNotEmpty())
+                                <div data-recent-books class="flex max-w-full items-center gap-2 overflow-x-auto pb-1 [-webkit-overflow-scrolling:touch]">
+                                    <p id="recent-books-label" class="shrink-0 text-xs font-medium text-gray-500 dark:text-gray-400">
+                                        Recent
+                                    </p>
+
+                                    <div class="flex min-w-0 flex-nowrap gap-2" role="group" aria-labelledby="recent-books-label">
+                                        @foreach ($recentBooks as $recentBook)
+                                            @php
+                                                $spineClass = match ($recentBook['testament']) {
+                                                    'new' => 'bg-primary-500 dark:bg-primary-400',
+                                                    'deuterocanonical' => 'bg-purple-500 dark:bg-purple-400',
+                                                    default => 'bg-accent-500 dark:bg-accent-400',
+                                                };
+                                            @endphp
+
+                                            <button
+                                                type="button"
+                                                data-recent-book-suggestion="{{ $recentBook['id'] }}"
+                                                @click="selectRecentBook(@js($recentBook))"
+                                                x-bind:aria-pressed="selectedBook == '{{ $recentBook['id'] }}'"
+                                                x-bind:class="selectedBook == '{{ $recentBook['id'] }}'
+                                                    ? 'border-primary-500 bg-primary-50 text-primary-800 ring-2 ring-primary-500/25 dark:border-primary-400 dark:bg-primary-900/30 dark:text-primary-100'
+                                                    : 'border-gray-200 bg-gray-50 text-gray-700 hover:border-gray-300 hover:bg-gray-100 hover:text-gray-900 dark:border-gray-700 dark:bg-gray-800/80 dark:text-gray-300 dark:hover:border-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-100'"
+                                                class="inline-flex min-h-9 max-w-[11rem] shrink-0 items-center gap-1.5 rounded-full border px-2.5 py-1 text-left text-xs font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-primary-400 dark:focus-visible:ring-offset-gray-900"
+                                            >
+                                                <span aria-hidden="true" class="h-1.5 w-1.5 shrink-0 rounded-full {{ $spineClass }}"></span>
+                                                <span class="truncate">{{ $recentBook['name'] }}</span>
+                                            </button>
+                                        @endforeach
+                                    </div>
+                                </div>
+                            @endif
+
                             @if ($errors->first('book_id'))
                                 <p class="form-error" role="alert">
                                     {{ $errors->first('book_id') }}
@@ -189,10 +230,10 @@
                         <div>
                             <div class="grid grid-cols-2 gap-4">
                                 <x-ui.input name="start_chapter" label="Start Chapter" inputmode="numeric" pattern="[0-9]*"
-                                    x-bind:placeholder="startChapterPlaceholder" :value="old('start_chapter')" required />
+                                    x-bind:placeholder="startChapterPlaceholder" :value="$selectedStartChapter" required />
 
                                 <x-ui.input name="end_chapter" label="End Chapter (Optional)" inputmode="numeric"
-                                    pattern="[0-9]*" x-bind:placeholder="endChapterPlaceholder" :value="old('end_chapter')"
+                                    pattern="[0-9]*" x-bind:placeholder="endChapterPlaceholder" :value="$selectedEndChapter"
                                     :error="$errors->first('end_chapter')" />
                             </div>
 
@@ -216,7 +257,7 @@
 
                             <div x-show="notesOpen" x-cloak>
                                 <x-ui.textarea name="notes_text" label="Note or reflection"
-                                    placeholder="Share any thoughts, insights, or questions from your reading..." :value="old('notes_text')"
+                                    placeholder="Share any thoughts, insights, or questions from your reading..." :value="$selectedNotesText"
                                     rows="3" maxlength="1000" :showCounter="true" :error="$errors->first('notes_text')" />
                             </div>
                         </div>
@@ -267,6 +308,7 @@
                                 testament: config.initialTestament,
                                 testamentLabel: testamentLabelFor(config.initialTestament),
                                 books: config.books,
+                                recentBooks: config.recentBooks,
                                 selectedBook: config.initialBookId,
                                 graceHelpOpen: false,
                                 notesOpen: config.initialNotesOpen,
@@ -298,6 +340,13 @@
                                         this.endChapterPlaceholder = 'e.g. 5';
                                         this.chapterNote = '';
                                     }
+                                },
+
+                                selectRecentBook(book) {
+                                    this.testament = book.testament;
+                                    this.testamentLabel = testamentLabelFor(book.testament);
+                                    this.selectedBook = String(book.id);
+                                    this.updateChapterPlaceholder(book.id);
                                 },
 
                                 updateTestament(newTestament) {

--- a/tests/Feature/ReadingLogRecentBooksTest.php
+++ b/tests/Feature/ReadingLogRecentBooksTest.php
@@ -1,0 +1,159 @@
+<?php
+
+use App\Models\ReadingLog;
+use App\Models\User;
+use Carbon\Carbon;
+
+function createRecentBookLog(User $user, int $bookId, string $dateRead, string $createdAt, int $chapter = 1): ReadingLog
+{
+    return ReadingLog::factory()->for($user)->create([
+        'book_id' => $bookId,
+        'chapter' => $chapter,
+        'passage_text' => "Book {$bookId} {$chapter}",
+        'date_read' => $dateRead,
+        'created_at' => Carbon::parse($createdAt),
+        'updated_at' => Carbon::parse($createdAt),
+    ]);
+}
+
+it('does not render recent book suggestions when the user has no reading history', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->get(route('logs.create'))
+        ->assertSuccessful()
+        ->assertDontSee('data-recent-books', false)
+        ->assertDontSee('data-recent-book-suggestion', false);
+});
+
+it('renders up to three distinct recent books ordered by latest reading recency', function () {
+    $user = User::factory()->create();
+
+    createRecentBookLog($user, 19, '2026-06-20', '2026-06-20 08:00:00');
+    createRecentBookLog($user, 43, '2026-06-23', '2026-06-23 09:00:00');
+    createRecentBookLog($user, 40, '2026-06-23', '2026-06-23 10:00:00');
+    createRecentBookLog($user, 1, '2026-06-22', '2026-06-22 08:00:00');
+    createRecentBookLog($user, 1, '2026-06-24', '2026-06-24 08:00:00', 2);
+
+    $response = $this->actingAs($user)->get(route('logs.create'));
+
+    $response->assertSuccessful()
+        ->assertSee('data-recent-books', false)
+        ->assertSee('Recent')
+        ->assertDontSee('RECENTLY READ')
+        ->assertDontSee('Tap a book to fill the selector.')
+        ->assertDontSee('Choose another book')
+        ->assertSee('flex max-w-full items-center gap-2 overflow-x-auto', false)
+        ->assertSee('role="group" aria-labelledby="recent-books-label"', false)
+        ->assertSee('x-bind:aria-pressed', false)
+        ->assertSee('inline-flex min-h-9 max-w-[11rem] shrink-0 items-center gap-1.5 rounded-full', false)
+        ->assertSee('h-1.5 w-1.5 shrink-0 rounded-full', false)
+        ->assertSee('focus-visible:ring-2', false)
+        ->assertDontSee('grid grid-cols-1 gap-2 sm:grid-cols-3', false)
+        ->assertDontSee('inline-flex min-h-11 w-full items-center', false)
+        ->assertSeeInOrder([
+            'data-recent-book-suggestion="1"',
+            'data-recent-book-suggestion="40"',
+            'data-recent-book-suggestion="43"',
+        ], false)
+        ->assertDontSee('data-recent-book-suggestion="19"', false);
+
+    expect(substr_count($response->getContent(), 'data-recent-book-suggestion='))->toBe(3);
+});
+
+it('renders only the available recent books when fewer than three distinct books exist', function () {
+    $user = User::factory()->create();
+
+    createRecentBookLog($user, 1, '2026-06-23', '2026-06-23 08:00:00');
+    createRecentBookLog($user, 43, '2026-06-24', '2026-06-24 08:00:00');
+
+    $response = $this->actingAs($user)->get(route('logs.create'));
+
+    $response->assertSuccessful()
+        ->assertSeeInOrder([
+            'data-recent-book-suggestion="43"',
+            'data-recent-book-suggestion="1"',
+        ], false);
+
+    expect(substr_count($response->getContent(), 'data-recent-book-suggestion='))->toBe(2);
+});
+
+it('filters deuterocanonical recent books by the current canon preference before limiting', function () {
+    $user = User::factory()->create();
+
+    createRecentBookLog($user, 67, '2026-06-24', '2026-06-24 12:00:00');
+    createRecentBookLog($user, 1, '2026-06-23', '2026-06-23 12:00:00');
+    createRecentBookLog($user, 40, '2026-06-22', '2026-06-22 12:00:00');
+    createRecentBookLog($user, 43, '2026-06-21', '2026-06-21 12:00:00');
+
+    $this->actingAs($user)
+        ->get(route('logs.create'))
+        ->assertSuccessful()
+        ->assertDontSee('data-recent-book-suggestion="67"', false)
+        ->assertSeeInOrder([
+            'data-recent-book-suggestion="1"',
+            'data-recent-book-suggestion="40"',
+            'data-recent-book-suggestion="43"',
+        ], false);
+
+    $user->forceFill(['deuterocanonical_books_enabled_at' => now()])->save();
+
+    $this->actingAs($user)
+        ->get(route('logs.create'))
+        ->assertSuccessful()
+        ->assertSeeInOrder([
+            'data-recent-book-suggestion="67"',
+            'data-recent-book-suggestion="1"',
+            'data-recent-book-suggestion="40"',
+        ], false);
+});
+
+it('preserves selected book, chapter input, notes, and suggestions after htmx validation replacement', function () {
+    $user = User::factory()->create();
+
+    createRecentBookLog($user, 1, '2026-06-23', '2026-06-23 08:00:00');
+    createRecentBookLog($user, 43, '2026-06-24', '2026-06-24 08:00:00');
+
+    $response = $this->actingAs($user)->post(route('logs.store'), [
+        'book_id' => 43,
+        'start_chapter' => '10',
+        'end_chapter' => '5',
+        'date_read' => today()->toDateString(),
+        'notes_text' => 'Keep this reflection visible.',
+    ], ['HX-Request' => 'true']);
+
+    $response->assertSuccessful()
+        ->assertSee('Invalid chapter range')
+        ->assertSee('data-recent-book-suggestion="43"', false)
+        ->assertSee("initialBookId: '43'", false)
+        ->assertSee('value="10"', false)
+        ->assertSee('value="5"', false)
+        ->assertSee('Keep this reflection visible.');
+});
+
+it('refreshes suggestions and resets chapter and note inputs after a successful htmx submission', function () {
+    $user = User::factory()->create();
+
+    createRecentBookLog($user, 1, '2026-06-22', '2026-06-22 08:00:00');
+    createRecentBookLog($user, 43, '2026-06-23', '2026-06-23 08:00:00');
+
+    $response = $this->actingAs($user)->post(route('logs.store'), [
+        'book_id' => 40,
+        'start_chapter' => '4',
+        'date_read' => today()->toDateString(),
+        'notes_text' => 'Do not carry this forward.',
+    ], ['HX-Request' => 'true']);
+
+    $response->assertSuccessful()
+        ->assertHeader('HX-Trigger', 'readingLogAdded')
+        ->assertSee('Matthew 4 recorded')
+        ->assertSeeInOrder([
+            'data-recent-book-suggestion="40"',
+            'data-recent-book-suggestion="43"',
+            'data-recent-book-suggestion="1"',
+        ], false)
+        ->assertSee("initialBookId: ''", false)
+        ->assertDontSee('Do not carry this forward.');
+
+    expect($response->getContent())->toMatch('/<input[^>]+name="start_chapter"[^>]+value=""/s');
+});

--- a/tests/Feature/ReadingLogRecentBooksTest.php
+++ b/tests/Feature/ReadingLogRecentBooksTest.php
@@ -68,6 +68,8 @@ it('renders up to three distinct recent books ordered by latest reading recency'
         ->assertDontSee('Tap a book to fill the selector.')
         ->assertDontSee('Choose another book')
         ->assertSee('flex max-w-full items-center gap-2 overflow-x-auto', false)
+        ->assertSee('![scrollbar-width:none]', false)
+        ->assertSee('[&::-webkit-scrollbar]:!hidden', false)
         ->assertSee('role="group" aria-labelledby="recent-books-label"', false)
         ->assertSee('x-bind:aria-pressed', false)
         ->assertSee('inline-flex min-h-9 max-w-[11rem] shrink-0 items-center gap-1.5 rounded-full', false)

--- a/tests/Feature/ReadingLogRecentBooksTest.php
+++ b/tests/Feature/ReadingLogRecentBooksTest.php
@@ -4,17 +4,41 @@ use App\Models\ReadingLog;
 use App\Models\User;
 use Carbon\Carbon;
 
-function createRecentBookLog(User $user, int $bookId, string $dateRead, string $createdAt, int $chapter = 1): ReadingLog
-{
-    return ReadingLog::factory()->for($user)->create([
-        'book_id' => $bookId,
-        'chapter' => $chapter,
-        'passage_text' => "Book {$bookId} {$chapter}",
-        'date_read' => $dateRead,
-        'created_at' => Carbon::parse($createdAt),
-        'updated_at' => Carbon::parse($createdAt),
-    ]);
+if (! function_exists('createRecentBookLog')) {
+    function createRecentBookLog(User $user, int $bookId, string $dateRead, string $createdAt, int $chapter = 1): ReadingLog
+    {
+        return ReadingLog::factory()->for($user)->create([
+            'book_id' => $bookId,
+            'chapter' => $chapter,
+            'passage_text' => "Book {$bookId} {$chapter}",
+            'date_read' => $dateRead,
+            'created_at' => Carbon::parse($createdAt),
+            'updated_at' => Carbon::parse($createdAt),
+        ]);
+    }
 }
+
+it('drops malformed array inputs when preserving values after htmx validation replacement', function () {
+    $user = User::factory()->create();
+
+    createRecentBookLog($user, 43, '2026-06-24', '2026-06-24 08:00:00');
+
+    $response = $this->actingAs($user)->post(route('logs.store'), [
+        'book_id' => [43],
+        'start_chapter' => ['10'],
+        'end_chapter' => ['5'],
+        'date_read' => today()->toDateString(),
+        'notes_text' => ['Keep this reflection visible.'],
+    ], ['HX-Request' => 'true']);
+
+    $response->assertSuccessful()
+        ->assertSee('data-recent-book-suggestion="43"', false)
+        ->assertSee("initialBookId: ''", false)
+        ->assertDontSee('Array');
+
+    expect($response->getContent())->toMatch('/<input[^>]+name="start_chapter"[^>]+value=""/s')
+        ->and($response->getContent())->toMatch('/<input[^>]+name="end_chapter"[^>]+value=""/s');
+});
 
 it('does not render recent book suggestions when the user has no reading history', function () {
     $user = User::factory()->create();

--- a/tests/Unit/ReadingFormServiceTest.php
+++ b/tests/Unit/ReadingFormServiceTest.php
@@ -4,7 +4,9 @@ namespace Tests\Unit;
 
 use App\Models\ReadingLog;
 use App\Models\User;
+use App\Services\BibleReferenceService;
 use App\Services\ReadingFormService;
+use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
@@ -21,7 +23,7 @@ class ReadingFormServiceTest extends TestCase
     {
         parent::setUp();
 
-        $this->service = new ReadingFormService;
+        $this->service = new ReadingFormService(new BibleReferenceService);
         $this->user = User::factory()->create();
     }
 
@@ -160,6 +162,7 @@ class ReadingFormServiceTest extends TestCase
         $contextData = $this->service->getFormContextData($this->user);
 
         $this->assertTrue($contextData['allowYesterday']);
+        $this->assertSame([], $contextData['recentBooks']);
     }
 
     public function test_get_form_context_data_allows_yesterday_for_a_new_user(): void
@@ -207,7 +210,59 @@ class ReadingFormServiceTest extends TestCase
         $this->assertTrue($contextData['allowYesterday']);
     }
 
-    public function test_get_form_context_data_does_not_query_unused_reading_state(): void
+    public function test_get_form_context_data_includes_three_distinct_recent_books_in_recency_order(): void
+    {
+        $this->createReadingLogForBook(19, '2026-06-20', '2026-06-20 08:00:00');
+        $this->createReadingLogForBook(43, '2026-06-23', '2026-06-23 09:00:00');
+        $this->createReadingLogForBook(40, '2026-06-23', '2026-06-23 10:00:00');
+        $this->createReadingLogForBook(1, '2026-06-22', '2026-06-22 08:00:00');
+        $this->createReadingLogForBook(1, '2026-06-24', '2026-06-24 08:00:00', 2);
+
+        $contextData = $this->service->getFormContextData($this->user);
+
+        $this->assertSame([1, 40, 43], array_column($contextData['recentBooks'], 'id'));
+        $this->assertSame(['Genesis', 'Matthew', 'John'], array_column($contextData['recentBooks'], 'name'));
+        $this->assertSame(['old', 'new', 'new'], array_column($contextData['recentBooks'], 'testament'));
+    }
+
+    public function test_get_form_context_data_filters_recent_books_by_current_canon_preference_before_limiting(): void
+    {
+        $this->createReadingLogForBook(67, '2026-06-24', '2026-06-24 12:00:00');
+        $this->createReadingLogForBook(1, '2026-06-23', '2026-06-23 12:00:00');
+        $this->createReadingLogForBook(40, '2026-06-22', '2026-06-22 12:00:00');
+        $this->createReadingLogForBook(43, '2026-06-21', '2026-06-21 12:00:00');
+
+        $contextData = $this->service->getFormContextData($this->user);
+
+        $this->assertSame([1, 40, 43], array_column($contextData['recentBooks'], 'id'));
+
+        $this->user->forceFill(['deuterocanonical_books_enabled_at' => now()])->save();
+
+        $contextData = $this->service->getFormContextData($this->user->fresh());
+
+        $this->assertSame([67, 1, 40], array_column($contextData['recentBooks'], 'id'));
+    }
+
+    public function test_get_form_context_data_finds_distinct_books_beyond_a_fixed_latest_row_window(): void
+    {
+        for ($daysAgo = 0; $daysAgo < 60; $daysAgo++) {
+            $date = Carbon::parse('2026-06-24')->subDays($daysAgo);
+
+            $this->createReadingLogForBook(
+                1,
+                $date->toDateString(),
+                $date->copy()->setTime(8, 0)->toDateTimeString()
+            );
+        }
+
+        $this->createReadingLogForBook(40, '2026-04-20', '2026-04-20 08:00:00');
+
+        $contextData = $this->service->getFormContextData($this->user);
+
+        $this->assertSame([1, 40], array_column($contextData['recentBooks'], 'id'));
+    }
+
+    public function test_get_form_context_data_uses_one_query_for_recent_books(): void
     {
         ReadingLog::factory()->create([
             'user_id' => $this->user->id,
@@ -221,6 +276,20 @@ class ReadingFormServiceTest extends TestCase
         $contextData = $this->service->getFormContextData($this->user);
 
         $this->assertTrue($contextData['allowYesterday']);
-        $this->assertEmpty(DB::getQueryLog());
+        $this->assertCount(1, DB::getQueryLog());
+        $this->assertSame([1], array_column($contextData['recentBooks'], 'id'));
+    }
+
+    private function createReadingLogForBook(int $bookId, string $dateRead, string $createdAt, int $chapter = 1): ReadingLog
+    {
+        return ReadingLog::factory()->create([
+            'user_id' => $this->user->id,
+            'book_id' => $bookId,
+            'chapter' => $chapter,
+            'passage_text' => "Book {$bookId} {$chapter}",
+            'date_read' => $dateRead,
+            'created_at' => Carbon::parse($createdAt),
+            'updated_at' => Carbon::parse($createdAt),
+        ]);
     }
 }


### PR DESCRIPTION
## Summary

- Add up to three canon-aware recent book suggestions to the reading log form, ordered by each distinct book's latest reading.
- Preserve submitted book, chapter, and note values during HTMX validation and duplicate-log replacement states.
- Render recent books as compact accessible chips, including mobile overflow/layout safeguards for the authenticated shell and form.
- Add focused feature and unit coverage for recency ordering, canon filtering, HTMX replacement behavior, and recent-chip UI output.

## Verification

- DB_DATABASE=:memory: php artisan test --compact tests/Feature/ReadingLogRecentBooksTest.php tests/Unit/ReadingFormServiceTest.php
- DB_DATABASE=:memory: php artisan test --compact tests/Feature/HtmxValidationDisplayTest.php tests/Feature/ReadingLogChapterInputTest.php tests/Feature/ReadingLogDeuterocanonicalTest.php
- vendor/bin/pint --dirty --format agent
- npm run build
- git diff --check
- git diff --cached --check
- Browser QA at 390px mobile and 1024px desktop: no page-level horizontal overflow, recent chips stay one row, chip click selects the book, no console errors

## Notes

- The default local database/testing.sqlite was malformed during verification, so focused PHP verification used DB_DATABASE=:memory:.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “recent books” suggestions to the reading log form for quicker entry.
  * Previously entered book, chapter, and notes values now stay filled in after a failed submission.

* **Bug Fixes**
  * Improved form behavior after validation and duplicate-entry errors.
  * Refined layout behavior in the authenticated area to better handle wide content.

* **Tests**
  * Added coverage for recent-book suggestions, selection order, and form state preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->