### PR TITLE
[DEL-273] Add Sanctum mobile token authentication

### DIFF
--- a/app/Http/Controllers/Api/V1/MobileTokenController.php
+++ b/app/Http/Controllers/Api/V1/MobileTokenController.php
@@ -8,7 +8,7 @@ use App\Http\Requests\Api\V1\StoreMobileTokenRequest;
 use App\Http\Resources\Api\V1\MobileTokenResource;
 use App\Models\User;
 use Illuminate\Http\Response;
-use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\ValidationException;
 
 class MobileTokenController extends Controller
@@ -16,14 +16,18 @@ class MobileTokenController extends Controller
     public function store(StoreMobileTokenRequest $request): MobileTokenResource
     {
         $credentials = $request->validated();
-        $user = User::query()->where('email', $credentials['email'])->first();
 
-        if (! $user || ! Hash::check($credentials['password'], $user->password)) {
+        if (! Auth::guard('web')->once([
+            'email' => $credentials['email'],
+            'password' => $credentials['password'],
+        ])) {
             throw ValidationException::withMessages([
                 'email' => [__('auth.failed')],
             ]);
         }
 
+        /** @var User $user */
+        $user = Auth::guard('web')->user();
         $token = $user->createToken($credentials['device_name'], ['mobile']);
 
         return new MobileTokenResource([

--- a/app/Http/Controllers/Api/V1/MobileTokenController.php
+++ b/app/Http/Controllers/Api/V1/MobileTokenController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\V1\DestroyMobileTokenRequest;
+use App\Http\Requests\Api\V1\StoreMobileTokenRequest;
+use App\Http\Resources\Api\V1\MobileTokenResource;
+use App\Models\User;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\ValidationException;
+
+class MobileTokenController extends Controller
+{
+    public function store(StoreMobileTokenRequest $request): MobileTokenResource
+    {
+        $credentials = $request->validated();
+        $user = User::query()->where('email', $credentials['email'])->first();
+
+        if (! $user || ! Hash::check($credentials['password'], $user->password)) {
+            throw ValidationException::withMessages([
+                'email' => [__('auth.failed')],
+            ]);
+        }
+
+        $token = $user->createToken($credentials['device_name'], ['mobile']);
+
+        return new MobileTokenResource([
+            'plain_text_token' => $token->plainTextToken,
+            'user' => $user,
+        ]);
+    }
+
+    public function destroy(DestroyMobileTokenRequest $request): Response
+    {
+        $request->user()->currentAccessToken()?->delete();
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Requests/Api/V1/DestroyMobileTokenRequest.php
+++ b/app/Http/Requests/Api/V1/DestroyMobileTokenRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests\Api\V1;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class DestroyMobileTokenRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/app/Http/Requests/Api/V1/StoreMobileTokenRequest.php
+++ b/app/Http/Requests/Api/V1/StoreMobileTokenRequest.php
@@ -30,6 +30,26 @@ class StoreMobileTokenRequest extends FormRequest
         ];
     }
 
+    /**
+     * Get the validation error messages for the request.
+     *
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'email.required' => 'An email address is required.',
+            'email.string' => 'The email address must be a string.',
+            'email.email' => 'Enter a valid email address.',
+            'email.max' => 'The email address may not be greater than 255 characters.',
+            'password.required' => 'A password is required.',
+            'password.string' => 'The password must be a string.',
+            'device_name.required' => 'A device name is required.',
+            'device_name.string' => 'The device name must be a string.',
+            'device_name.max' => 'The device name may not be greater than 255 characters.',
+        ];
+    }
+
     protected function prepareForValidation(): void
     {
         $email = $this->input('email');

--- a/app/Http/Requests/Api/V1/StoreMobileTokenRequest.php
+++ b/app/Http/Requests/Api/V1/StoreMobileTokenRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Requests\Api\V1;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Str;
+
+class StoreMobileTokenRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'email' => ['required', 'string', 'email', 'max:255'],
+            'password' => ['required', 'string'],
+            'device_name' => ['required', 'string', 'max:255'],
+        ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $email = $this->input('email');
+
+        if (is_string($email)) {
+            $this->merge([
+                'email' => Str::lower($email),
+            ]);
+        }
+    }
+}

--- a/app/Http/Resources/Api/V1/MobileTokenResource.php
+++ b/app/Http/Resources/Api/V1/MobileTokenResource.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Resources\Api\V1;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class MobileTokenResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'token' => $this->resource['plain_text_token'],
+            'token_type' => 'Bearer',
+            'user' => new MobileUserResource($this->resource['user']),
+        ];
+    }
+}

--- a/app/Http/Resources/Api/V1/MobileUserResource.php
+++ b/app/Http/Resources/Api/V1/MobileUserResource.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Resources\Api\V1;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class MobileUserResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->resource->id,
+            'name' => $this->resource->name,
+            'email' => $this->resource->email,
+        ];
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -5,16 +5,18 @@ namespace App\Models;
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use App\Notifications\CustomResetPasswordNotification;
 use App\Services\EmailService;
+use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Laravel\Sanctum\HasApiTokens;
 use NotificationChannels\WebPush\HasPushSubscriptions;
 
 class User extends Authenticatable
 {
-    /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, HasPushSubscriptions, Notifiable;
+    /** @use HasFactory<UserFactory> */
+    use HasApiTokens, HasFactory, HasPushSubscriptions, Notifiable;
 
     /**
      * The attributes that are mass assignable.

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvi
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Str;
 
 class RouteServiceProvider extends ServiceProvider
 {
@@ -24,6 +25,16 @@ class RouteServiceProvider extends ServiceProvider
     {
         RateLimiter::for('api', function (Request $request) {
             return Limit::perMinute(60)->by($request->user()?->id ?: $request->ip());
+        });
+
+        RateLimiter::for('mobile-login', function (Request $request) {
+            $email = $request->input('email');
+            $normalizedEmail = is_string($email) ? Str::lower($email) : 'invalid-email';
+            $throttleKey = Str::transliterate($normalizedEmail.'|'.$request->ip());
+
+            $limit = app()->environment('local') ? 20 : 5;
+
+            return Limit::perMinute($limit)->by($throttleKey);
         });
 
         $this->routes(function () {

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -5,6 +5,7 @@ use App\Http\Middleware\SecurityHeadersMiddleware;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Laravel\Sanctum\Http\Middleware\CheckAbilities;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -12,7 +13,11 @@ return Application::configure(basePath: dirname(__DIR__))
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )
-    ->withMiddleware(function (Middleware $middleware) {
+    ->withMiddleware(function (Middleware $middleware): void {
+        $middleware->alias([
+            'abilities' => CheckAbilities::class,
+        ]);
+
         $middleware->validateCsrfTokens(except: [
             'marketing/unsubscribe/*/one-click',
         ]);

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "laravel-notification-channels/webpush": "^11.0",
         "laravel/fortify": "^1.27",
         "laravel/framework": "^12.0",
+        "laravel/sanctum": "^4.3",
         "laravel/socialite": "^5.23",
         "laravel/telescope": "^5.10",
         "laravel/tinker": "^2.10.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5a5eb4eed3ffc4c1c9edb6f0f2ac97a0",
+    "content-hash": "c2e7d46e080022f07cebcf1b1747b577",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -1755,6 +1755,69 @@
                 "source": "https://github.com/laravel/prompts/tree/v0.3.22"
             },
             "time": "2026-08-04T14:50:50+00:00"
+        },
+        {
+            "name": "laravel/sanctum",
+            "version": "v4.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/sanctum.git",
+                "reference": "fee27a573d1a013af3721d86153a65e0b11927e6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/sanctum/zipball/fee27a573d1a013af3721d86153a65e0b11927e6",
+                "reference": "fee27a573d1a013af3721d86153a65e0b11927e6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "illuminate/console": "^11.0|^12.0|^13.0",
+                "illuminate/contracts": "^11.0|^12.0|^13.0",
+                "illuminate/database": "^11.0|^12.0|^13.0",
+                "illuminate/support": "^11.0|^12.0|^13.0",
+                "php": "^8.2",
+                "symfony/console": "^7.0|^8.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.6",
+                "orchestra/testbench": "^9.15|^10.8|^11.0",
+                "phpstan/phpstan": "^1.10"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Sanctum\\SanctumServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Sanctum\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Laravel Sanctum provides a featherweight authentication system for SPAs and simple APIs.",
+            "keywords": [
+                "auth",
+                "laravel",
+                "sanctum"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/sanctum/issues",
+                "source": "https://github.com/laravel/sanctum"
+            },
+            "time": "2026-06-23T18:26:55+00:00"
         },
         {
             "name": "laravel/sentinel",

--- a/database/migrations/2026_08_07_231559_create_personal_access_tokens_table.php
+++ b/database/migrations/2026_08_07_231559_create_personal_access_tokens_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('personal_access_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('tokenable');
+            $table->text('name');
+            $table->string('token', 64)->unique();
+            $table->text('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable()->index();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('personal_access_tokens');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Api\V1\MobileTokenController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -18,4 +19,12 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
 
-// Future API routes for mobile apps will be added here in post-MVP phases
+Route::prefix('v1')->name('api.v1.')->group(function (): void {
+    Route::post('/auth/token', [MobileTokenController::class, 'store'])
+        ->middleware('throttle:mobile-login')
+        ->name('auth.token.store');
+
+    Route::delete('/auth/token', [MobileTokenController::class, 'destroy'])
+        ->middleware(['auth:sanctum', 'abilities:mobile'])
+        ->name('auth.token.destroy');
+});

--- a/tests/Feature/Api/V1/MobileTokenAuthenticationTest.php
+++ b/tests/Feature/Api/V1/MobileTokenAuthenticationTest.php
@@ -65,6 +65,42 @@ it('returns the same generic validation response for invalid credentials', funct
     ]],
 ]);
 
+it('timeboxes credential verification for an unknown account', function () {
+    $startedAt = hrtime(true);
+
+    $this->postJson('/api/v1/auth/token', [
+        'email' => 'unknown@example.com',
+        'password' => 'wrong-password',
+        'device_name' => 'Pixel',
+    ])->assertUnprocessable();
+
+    $elapsedMilliseconds = (hrtime(true) - $startedAt) / 1_000_000;
+
+    expect($elapsedMilliseconds)->toBeGreaterThanOrEqual(150);
+});
+
+it('rehashes stale passwords after successful mobile login', function () {
+    $password = 'ValidPass123!';
+    $configuredCost = password_get_info(Hash::make($password))['options']['cost'];
+    $user = User::factory()->create([
+        'email' => 'reader@example.com',
+    ]);
+    $staleHash = password_hash($password, PASSWORD_BCRYPT, ['cost' => $configuredCost + 1]);
+
+    User::query()->whereKey($user)->toBase()->update(['password' => $staleHash]);
+    $user->refresh();
+
+    expect(Hash::needsRehash($user->password))->toBeTrue();
+
+    $this->postJson('/api/v1/auth/token', [
+        'email' => $user->email,
+        'password' => $password,
+        'device_name' => 'Pixel',
+    ])->assertSuccessful();
+
+    expect(Hash::needsRehash($user->fresh()->password))->toBeFalse();
+});
+
 it('limits production attempts by normalized email and IP', function () {
     $this->app->detectEnvironment(fn (): string => 'production');
 
@@ -94,6 +130,43 @@ it('validates malformed email values after applying the login limiter', function
         ->assertUnprocessable()
         ->assertJsonValidationErrors('email');
 });
+
+it('returns clear mobile credential validation messages', function (array $payload, string $field, string $message) {
+    $response = $this->postJson('/api/v1/auth/token', $payload)->assertUnprocessable();
+
+    expect($response->json("errors.{$field}"))->toContain($message);
+})->with([
+    'email required' => [
+        ['password' => 'ValidPass123!', 'device_name' => 'Pixel'],
+        'email',
+        'An email address is required.',
+    ],
+    'email invalid' => [
+        ['email' => 'not-an-email', 'password' => 'ValidPass123!', 'device_name' => 'Pixel'],
+        'email',
+        'Enter a valid email address.',
+    ],
+    'email maximum length' => [
+        ['email' => str_repeat('a', 250).'@example.com', 'password' => 'ValidPass123!', 'device_name' => 'Pixel'],
+        'email',
+        'The email address may not be greater than 255 characters.',
+    ],
+    'password required' => [
+        ['email' => 'reader@example.com', 'device_name' => 'Pixel'],
+        'password',
+        'A password is required.',
+    ],
+    'device name required' => [
+        ['email' => 'reader@example.com', 'password' => 'ValidPass123!'],
+        'device_name',
+        'A device name is required.',
+    ],
+    'device name maximum length' => [
+        ['email' => 'reader@example.com', 'password' => 'ValidPass123!', 'device_name' => str_repeat('a', 256)],
+        'device_name',
+        'The device name may not be greater than 255 characters.',
+    ],
+]);
 
 it('rejects logout without a token', function () {
     $this->deleteJson('/api/v1/auth/token')->assertUnauthorized();

--- a/tests/Feature/Api/V1/MobileTokenAuthenticationTest.php
+++ b/tests/Feature/Api/V1/MobileTokenAuthenticationTest.php
@@ -1,0 +1,137 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\PersonalAccessToken;
+
+it('issues a non-expiring mobile bearer token for valid normalized credentials', function () {
+    $user = User::factory()->create([
+        'email' => 'reader@example.com',
+        'password' => Hash::make('ValidPass123!'),
+    ]);
+
+    $response = $this->postJson('/api/v1/auth/token', [
+        'email' => 'READER@EXAMPLE.COM',
+        'password' => 'ValidPass123!',
+        'device_name' => 'Orlando Pixel',
+    ]);
+
+    $response
+        ->assertSuccessful()
+        ->assertJsonPath('data.token_type', 'Bearer')
+        ->assertJsonPath('data.user.id', $user->id)
+        ->assertJsonPath('data.user.name', $user->name)
+        ->assertJsonPath('data.user.email', $user->email)
+        ->assertJsonStructure([
+            'data' => [
+                'token',
+                'token_type',
+                'user' => ['id', 'name', 'email'],
+            ],
+        ]);
+
+    $plainTextToken = $response->json('data.token');
+    $accessToken = PersonalAccessToken::findToken($plainTextToken);
+
+    expect($plainTextToken)->toStartWith($accessToken->getKey().'|')
+        ->and($accessToken->name)->toBe('Orlando Pixel')
+        ->and($accessToken->abilities)->toBe(['mobile'])
+        ->and($accessToken->expires_at)->toBeNull()
+        ->and($accessToken->token)->not->toBe($plainTextToken);
+});
+
+it('returns the same generic validation response for invalid credentials', function (array $credentials) {
+    User::factory()->create([
+        'email' => 'reader@example.com',
+        'password' => Hash::make('ValidPass123!'),
+    ]);
+
+    $this->postJson('/api/v1/auth/token', $credentials + ['device_name' => 'Pixel'])
+        ->assertUnprocessable()
+        ->assertExactJson([
+            'message' => __('auth.failed'),
+            'errors' => [
+                'email' => [__('auth.failed')],
+            ],
+        ]);
+})->with([
+    'existing account with wrong password' => [[
+        'email' => 'reader@example.com',
+        'password' => 'wrong-password',
+    ]],
+    'unknown account' => [[
+        'email' => 'unknown@example.com',
+        'password' => 'wrong-password',
+    ]],
+]);
+
+it('limits production attempts by normalized email and IP', function () {
+    $this->app->detectEnvironment(fn (): string => 'production');
+
+    foreach (range(1, 5) as $attempt) {
+        $email = $attempt % 2 === 0 ? 'READER@example.com' : 'reader@EXAMPLE.com';
+
+        $this->postJson('/api/v1/auth/token', [
+            'email' => $email,
+            'password' => 'wrong-password',
+            'device_name' => 'Pixel',
+        ])->assertUnprocessable();
+    }
+
+    $this->postJson('/api/v1/auth/token', [
+        'email' => 'reader@example.com',
+        'password' => 'wrong-password',
+        'device_name' => 'Pixel',
+    ])->assertTooManyRequests();
+});
+
+it('validates malformed email values after applying the login limiter', function () {
+    $this->postJson('/api/v1/auth/token', [
+        'email' => ['reader@example.com'],
+        'password' => 'wrong-password',
+        'device_name' => 'Pixel',
+    ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors('email');
+});
+
+it('rejects logout without a token', function () {
+    $this->deleteJson('/api/v1/auth/token')->assertUnauthorized();
+});
+
+it('rejects logout when the token lacks the mobile ability', function () {
+    $user = User::factory()->create();
+    $token = $user->createToken('Web integration', ['reporting'])->plainTextToken;
+
+    $this->withToken($token)
+        ->deleteJson('/api/v1/auth/token')
+        ->assertForbidden();
+
+    expect($user->tokens()->count())->toBe(1);
+});
+
+it('revokes only the current mobile token and invalidates it', function () {
+    $user = User::factory()->create();
+    $currentToken = $user->createToken('Current Pixel', ['mobile'])->plainTextToken;
+    $otherToken = $user->createToken('Other device', ['mobile'])->plainTextToken;
+
+    $this->withToken($currentToken)
+        ->deleteJson('/api/v1/auth/token')
+        ->assertNoContent();
+
+    expect(PersonalAccessToken::findToken($currentToken))->toBeNull()
+        ->and(PersonalAccessToken::findToken($otherToken))->not->toBeNull()
+        ->and($user->tokens()->pluck('name')->all())->toBe(['Other device']);
+
+    $this->app['auth']->forgetGuards();
+
+    $this->withToken($currentToken)
+        ->deleteJson('/api/v1/auth/token')
+        ->assertUnauthorized();
+
+    $this->app['auth']->forgetGuards();
+
+    $this->withToken($otherToken)
+        ->deleteJson('/api/v1/auth/token')
+        ->assertNoContent();
+});


### PR DESCRIPTION
## Problem

The Android-first mobile V1 needs versioned personal-access-token authentication without changing Delight's existing Fortify or Google web authentication behavior.

Linear: [DEL-273 — Add Sanctum mobile token authentication](https://linear.app/orlando-dev/issue/DEL-273/add-sanctum-mobile-token-authentication)

## Implementation

- add Laravel Sanctum `v4.3.3` and publish a new `personal_access_tokens` migration
- add `HasApiTokens` to `User`
- add `POST /api/v1/auth/token` with Fortify-consistent email normalization and production throttling at five attempts per minute per normalized email and IP
- return a one-time plaintext Bearer token with the `mobile` ability and basic user identity through API resources
- add `DELETE /api/v1/auth/token`, protected by `auth:sanctum` and `abilities:mobile`, revoking only the current token
- return a generic 422 response for invalid credentials without disclosing account existence
- guard malformed rate-limiter input so validation returns 422 rather than 500

## Verification

- `php artisan test --compact tests/Feature/Api/V1/MobileTokenAuthenticationTest.php` — 8 passed, 41 assertions
- relevant Fortify, authentication, password-reset, Google-surface, and core validation tests — 51 passed, 219 assertions
- `vendor/bin/pint --dirty --format agent`
- `composer validate --strict --no-check-publish`
- `composer audit --locked --format=plain`
- PHP syntax checks for changed PHP files
- `git diff --check`
- real malformed-email HTTP request confirmed 422

## Scope

This PR does not add refresh tokens, native 2FA, native Google login, mobile UI, bootstrap or reading APIs, deploy anything, or alter existing web authentication flows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added mobile authentication with secure token issuance and logout.
  - Successful sign-in returns a bearer token and essential account details.
  - Added permission-based protection for mobile API access.
- **Security**
  - Added validation for email, password, and device information.
  - Added rate limiting for mobile sign-in attempts.
  - Revoked tokens can no longer be used.
- **Bug Fixes**
  - Invalid credentials now return a clear, localized validation response.
  - Email input is normalized before validation.
  - Improved handling of stale passwords and unknown accounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->