### PR TITLE
[codex] Clarify Delight project identity

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Bible Habit Builder
+# Contributing to Delight
 
 Thank you for considering contributing to this project!
 
@@ -32,4 +32,4 @@ Thank you for considering contributing to this project!
 
 - Be respectful and constructive in all communications.
 
-Thank you for helping make Bible Habit Builder better!
+Thank you for helping make Delight better!

--- a/README.md
+++ b/README.md
@@ -181,6 +181,12 @@ Run the test suite with:
 php artisan test
 ```
 
+## Project Identity
+
+Delight is an independent product created and maintained by Orlando Villanueva. Contributions are welcome, and the source code remains available under GPLv3.
+
+The Delight name, logo, visual identity, and official service at [mydelight.app](https://mydelight.app) remain associated with the original project. Forks and modified versions should use distinct branding and must not imply that they are official Delight releases or services.
+
 ## License
 
 This project is licensed under the GNU General Public License v3.0 - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
## Summary

Clarifies that Delight is an independent product created and maintained by Orlando Villanueva while continuing to welcome contributions under GPLv3.

Documents that the Delight name, logo, visual identity, and official service at mydelight.app remain associated with the original project. Forks and modified versions should use distinct branding and must not imply official Delight status.

Also updates `CONTRIBUTING.md` to consistently refer to the project as Delight instead of its former Bible Habit Builder name.

## Verification

- Confirmed the diff contains only `README.md` and `CONTRIBUTING.md`
- Ran `git diff --check`
- Confirmed `CONTRIBUTING.md` no longer contains `Bible Habit Builder`
- Confirmed the existing GPLv3 license statement and `LICENSE` file remain unchanged
- Documentation-only change; no application tests were necessary
