### PR TITLE
[DEL-275] Add the mobile bootstrap API

### DIFF
--- a/app/Http/Controllers/Api/V1/MobileBootstrapController.php
+++ b/app/Http/Controllers/Api/V1/MobileBootstrapController.php
@@ -33,7 +33,8 @@ class MobileBootstrapController extends Controller
             ),
             'recent_book_ids' => array_column($recentBooks, 'id'),
             'has_read_today' => $readingFormService->hasReadToday($user),
-            'statistics' => $userStatisticsService->getDashboardStatistics($user),
+            'streaks' => $userStatisticsService->getStreakStatistics($user),
+            'reading_summary' => $userStatisticsService->getReadingSummary($user),
         ]);
     }
 }

--- a/app/Http/Controllers/Api/V1/MobileBootstrapController.php
+++ b/app/Http/Controllers/Api/V1/MobileBootstrapController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\MobileBootstrapResource;
+use App\Models\User;
+use App\Services\BibleReferenceService;
+use App\Services\ReadingFormService;
+use App\Services\UserStatisticsService;
+use Illuminate\Http\Request;
+
+class MobileBootstrapController extends Controller
+{
+    public function __invoke(
+        Request $request,
+        BibleReferenceService $bibleReferenceService,
+        ReadingFormService $readingFormService,
+        UserStatisticsService $userStatisticsService,
+    ): MobileBootstrapResource {
+        /** @var User $user */
+        $user = $request->user();
+        $today = today();
+        $includeDeuterocanonical = $user->includesDeuterocanonicalBooks();
+        $recentBooks = $readingFormService->getRecentBooksForForm($user);
+
+        return new MobileBootstrapResource([
+            'user' => $user,
+            'today' => $today->toDateString(),
+            'yesterday' => $today->copy()->subDay()->toDateString(),
+            'books' => $bibleReferenceService->listBibleBooks(
+                includeDeuterocanonical: $includeDeuterocanonical,
+            ),
+            'recent_book_ids' => array_column($recentBooks, 'id'),
+            'has_read_today' => $readingFormService->hasReadToday($user),
+            'statistics' => $userStatisticsService->getDashboardStatistics($user),
+        ]);
+    }
+}

--- a/app/Http/Resources/Api/V1/MobileBootstrapResource.php
+++ b/app/Http/Resources/Api/V1/MobileBootstrapResource.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Resources\Api\V1;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class MobileBootstrapResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        $streaks = $this->resource['statistics']['streaks'];
+        $readingSummary = $this->resource['statistics']['reading_summary'];
+
+        return [
+            'user' => new MobileUserResource($this->resource['user']),
+            'today' => $this->resource['today'],
+            'yesterday' => $this->resource['yesterday'],
+            'books' => $this->resource['books'],
+            'recent_book_ids' => $this->resource['recent_book_ids'],
+            'has_read_today' => $this->resource['has_read_today'],
+            'current_streak' => $streaks['current_streak'],
+            'longest_streak' => $streaks['longest_streak'],
+            'this_week_days' => $readingSummary['this_week_days'],
+            'this_month_days' => $readingSummary['this_month_days'],
+            'activity' => $streaks['recent_reading_activity_series'],
+        ];
+    }
+}

--- a/app/Http/Resources/Api/V1/MobileBootstrapResource.php
+++ b/app/Http/Resources/Api/V1/MobileBootstrapResource.php
@@ -14,8 +14,8 @@ class MobileBootstrapResource extends JsonResource
      */
     public function toArray(Request $request): array
     {
-        $streaks = $this->resource['statistics']['streaks'];
-        $readingSummary = $this->resource['statistics']['reading_summary'];
+        $streaks = $this->resource['streaks'];
+        $readingSummary = $this->resource['reading_summary'];
 
         return [
             'user' => new MobileUserResource($this->resource['user']),

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Api\V1\MobileBootstrapController;
 use App\Http\Controllers\Api\V1\MobileTokenController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
@@ -27,4 +28,8 @@ Route::prefix('v1')->name('api.v1.')->group(function (): void {
     Route::delete('/auth/token', [MobileTokenController::class, 'destroy'])
         ->middleware(['auth:sanctum', 'abilities:mobile'])
         ->name('auth.token.destroy');
+
+    Route::get('/bootstrap', MobileBootstrapController::class)
+        ->middleware(['auth:sanctum', 'abilities:mobile'])
+        ->name('bootstrap');
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -25,11 +25,11 @@ Route::prefix('v1')->name('api.v1.')->group(function (): void {
         ->middleware('throttle:mobile-login')
         ->name('auth.token.store');
 
-    Route::delete('/auth/token', [MobileTokenController::class, 'destroy'])
-        ->middleware(['auth:sanctum', 'abilities:mobile'])
-        ->name('auth.token.destroy');
+    Route::middleware(['auth:sanctum', 'abilities:mobile'])->group(function (): void {
+        Route::delete('/auth/token', [MobileTokenController::class, 'destroy'])
+            ->name('auth.token.destroy');
 
-    Route::get('/bootstrap', MobileBootstrapController::class)
-        ->middleware(['auth:sanctum', 'abilities:mobile'])
-        ->name('bootstrap');
+        Route::get('/bootstrap', MobileBootstrapController::class)
+            ->name('bootstrap');
+    });
 });

--- a/tests/Feature/Api/V1/MobileBootstrapTest.php
+++ b/tests/Feature/Api/V1/MobileBootstrapTest.php
@@ -92,15 +92,17 @@ it('returns exactly the dates accepted by web reading validation', function (): 
             ->assertSuccessful();
     }
 
-    $this->actingAs($user)
+    $invalidDateResponse = $this->actingAs($user)
         ->post(route('logs.store'), [
             'book_id' => 1,
             'start_chapter' => 3,
             'date_read' => Carbon::parse($dates['yesterday'])->subDay()->toDateString(),
         ])
-        ->assertSuccessful();
+        ->assertSuccessful()
+        ->assertViewHas('errors');
 
-    expect($user->readingLogs()->count())->toBe(2);
+    expect($invalidDateResponse->viewData('errors')->has('date_read'))->toBeTrue()
+        ->and($user->readingLogs()->count())->toBe(2);
 });
 
 it('returns canon-aware books and filters recent books before limiting', function (): void {
@@ -135,7 +137,7 @@ it('returns canon-aware books and filters recent books before limiting', functio
         ->toContain(67, 73);
 });
 
-it('returns the existing dashboard statistics and fourteen-day activity counts', function (): void {
+it('returns the existing statistics and fourteen-day activity counts', function (): void {
     $user = User::factory()->create();
 
     createBootstrapReading($user, 1, MOBILE_BOOTSTRAP_TWO_DAYS_AGO, MOBILE_BOOTSTRAP_TWO_DAYS_AGO.' 08:00:00');
@@ -155,8 +157,35 @@ it('returns the existing dashboard statistics and fourteen-day activity counts',
         ->assertJsonPath('data.activity.12', ['date' => MOBILE_BOOTSTRAP_YESTERDAY, 'count' => 1])
         ->assertJsonPath('data.activity.13', ['date' => MOBILE_BOOTSTRAP_TODAY, 'count' => 2]);
 
-    expect(Cache::has("user_dashboard_stats_{$user->id}"))->toBeTrue()
-        ->and(Cache::has("user_recent_reading_activity_series_{$user->id}"))->toBeTrue();
+    expect(Cache::has("user_current_streak_{$user->id}"))->toBeTrue()
+        ->and(Cache::has("user_recent_reading_activity_series_{$user->id}"))->toBeTrue()
+        ->and(Cache::has("user_total_reading_days_{$user->id}"))->toBeTrue();
+});
+
+it('does not serve previous-day statistics after midnight', function (): void {
+    Carbon::setTestNow(Carbon::parse('2026-08-08 23:59:00', config('app.timezone')));
+
+    $user = User::factory()->create();
+    createBootstrapReading($user, 1, MOBILE_BOOTSTRAP_YESTERDAY, MOBILE_BOOTSTRAP_YESTERDAY.' 23:50:00');
+    $token = $user->createToken('Pixel', ['mobile'])->plainTextToken;
+
+    $this->withToken($token)
+        ->getJson(MOBILE_BOOTSTRAP_ENDPOINT)
+        ->assertSuccessful()
+        ->assertJsonPath('data.today', MOBILE_BOOTSTRAP_YESTERDAY)
+        ->assertJsonPath('data.activity.13', ['date' => MOBILE_BOOTSTRAP_YESTERDAY, 'count' => 1]);
+
+    Carbon::setTestNow(Carbon::parse(MOBILE_BOOTSTRAP_TODAY.' 00:01:00', config('app.timezone')));
+    $this->app['auth']->forgetGuards();
+
+    $this->withToken($token)
+        ->getJson(MOBILE_BOOTSTRAP_ENDPOINT)
+        ->assertSuccessful()
+        ->assertJsonPath('data.today', MOBILE_BOOTSTRAP_TODAY)
+        ->assertJsonPath('data.yesterday', MOBILE_BOOTSTRAP_YESTERDAY)
+        ->assertJsonPath('data.has_read_today', false)
+        ->assertJsonPath('data.this_week_days', 0)
+        ->assertJsonPath('data.activity.13', ['date' => MOBILE_BOOTSTRAP_TODAY, 'count' => 0]);
 });
 
 function createBootstrapReading(
@@ -166,7 +195,7 @@ function createBootstrapReading(
     string $createdAt,
     int $chapter = 1,
 ): ReadingLog {
-    return ReadingLog::factory()->for($user)->create([
+    return ReadingLog::factory()->for($user)->createOne([
         'book_id' => $bookId,
         'chapter' => $chapter,
         'passage_text' => "Book {$bookId} {$chapter}",

--- a/tests/Feature/Api/V1/MobileBootstrapTest.php
+++ b/tests/Feature/Api/V1/MobileBootstrapTest.php
@@ -1,0 +1,172 @@
+<?php
+
+use App\Models\ReadingLog;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Cache;
+
+beforeEach(function (): void {
+    Cache::flush();
+    Carbon::setTestNow(Carbon::parse('2026-08-09 00:30:00', config('app.timezone')));
+});
+
+afterEach(function (): void {
+    Cache::flush();
+    Carbon::setTestNow();
+});
+
+it('requires a Sanctum token with the mobile ability', function (): void {
+    $this->getJson('/api/v1/bootstrap')->assertUnauthorized();
+
+    $user = User::factory()->create();
+    $token = $user->createToken('Reporting integration', ['reporting'])->plainTextToken;
+
+    $this->withToken($token)
+        ->getJson('/api/v1/bootstrap')
+        ->assertForbidden();
+});
+
+it('returns complete zero-filled bootstrap data in the application timezone', function (): void {
+    $user = User::factory()->create();
+    $token = $user->createToken('Pixel', ['mobile'])->plainTextToken;
+
+    $response = $this->withToken($token)
+        ->getJson('/api/v1/bootstrap')
+        ->assertSuccessful()
+        ->assertJsonPath('data.user.id', $user->id)
+        ->assertJsonPath('data.user.name', $user->name)
+        ->assertJsonPath('data.user.email', $user->email)
+        ->assertJsonPath('data.today', '2026-08-09')
+        ->assertJsonPath('data.yesterday', '2026-08-08')
+        ->assertJsonPath('data.recent_book_ids', [])
+        ->assertJsonPath('data.has_read_today', false)
+        ->assertJsonPath('data.current_streak', 0)
+        ->assertJsonPath('data.longest_streak', 0)
+        ->assertJsonPath('data.this_week_days', 0)
+        ->assertJsonPath('data.this_month_days', 0)
+        ->assertJsonCount(66, 'data.books')
+        ->assertJsonCount(14, 'data.activity')
+        ->assertJsonStructure([
+            'data' => [
+                'user' => ['id', 'name', 'email'],
+                'today',
+                'yesterday',
+                'books' => ['*' => ['id', 'name', 'chapters', 'testament']],
+                'recent_book_ids',
+                'has_read_today',
+                'current_streak',
+                'longest_streak',
+                'this_week_days',
+                'this_month_days',
+                'activity' => ['*' => ['date', 'count']],
+            ],
+        ]);
+
+    expect($response->json('data.activity'))
+        ->toHaveCount(14)
+        ->and($response->json('data.activity.0'))->toBe(['date' => '2026-07-27', 'count' => 0])
+        ->and($response->json('data.activity.13'))->toBe(['date' => '2026-08-09', 'count' => 0]);
+});
+
+it('returns exactly the dates accepted by web reading validation', function (): void {
+    $user = User::factory()->create();
+    $token = $user->createToken('Pixel', ['mobile'])->plainTextToken;
+
+    $dates = $this->withToken($token)
+        ->getJson('/api/v1/bootstrap')
+        ->assertSuccessful()
+        ->json('data');
+
+    foreach (['today', 'yesterday'] as $index => $dateKey) {
+        $this->actingAs($user)
+            ->post(route('logs.store'), [
+                'book_id' => 1,
+                'start_chapter' => $index + 1,
+                'date_read' => $dates[$dateKey],
+            ])
+            ->assertSuccessful();
+    }
+
+    $this->actingAs($user)
+        ->post(route('logs.store'), [
+            'book_id' => 1,
+            'start_chapter' => 3,
+            'date_read' => Carbon::parse($dates['yesterday'])->subDay()->toDateString(),
+        ])
+        ->assertSuccessful();
+
+    expect($user->readingLogs()->count())->toBe(2);
+});
+
+it('returns canon-aware books and filters recent books before limiting', function (): void {
+    $user = User::factory()->create();
+
+    createBootstrapReading($user, 67, '2026-08-09', '2026-08-09 00:20:00');
+    createBootstrapReading($user, 1, '2026-08-08', '2026-08-08 12:00:00');
+    createBootstrapReading($user, 40, '2026-08-07', '2026-08-07 12:00:00');
+    createBootstrapReading($user, 43, '2026-08-06', '2026-08-06 12:00:00');
+    createBootstrapReading($user, 19, '2026-08-05', '2026-08-05 12:00:00');
+
+    $standardResponse = $this->withToken($user->createToken('Pixel', ['mobile'])->plainTextToken)
+        ->getJson('/api/v1/bootstrap')
+        ->assertSuccessful()
+        ->assertJsonCount(66, 'data.books')
+        ->assertJsonPath('data.recent_book_ids', [1, 40, 43]);
+
+    expect(collect($standardResponse->json('data.books'))->pluck('id')->all())
+        ->not->toContain(67);
+
+    $user->forceFill(['deuterocanonical_books_enabled_at' => now()])->save();
+    Cache::flush();
+    $this->app['auth']->forgetGuards();
+
+    $deuterocanonicalResponse = $this->withToken($user->createToken('Catholic Pixel', ['mobile'])->plainTextToken)
+        ->getJson('/api/v1/bootstrap')
+        ->assertSuccessful()
+        ->assertJsonCount(73, 'data.books')
+        ->assertJsonPath('data.recent_book_ids', [67, 1, 40]);
+
+    expect(collect($deuterocanonicalResponse->json('data.books'))->pluck('id')->all())
+        ->toContain(67, 73);
+});
+
+it('returns the existing dashboard statistics and fourteen-day activity counts', function (): void {
+    $user = User::factory()->create();
+
+    createBootstrapReading($user, 1, '2026-08-07', '2026-08-07 08:00:00');
+    createBootstrapReading($user, 1, '2026-08-08', '2026-08-08 08:00:00', 2);
+    createBootstrapReading($user, 1, '2026-08-09', '2026-08-09 00:10:00', 3);
+    createBootstrapReading($user, 40, '2026-08-09', '2026-08-09 00:20:00');
+
+    $this->withToken($user->createToken('Pixel', ['mobile'])->plainTextToken)
+        ->getJson('/api/v1/bootstrap')
+        ->assertSuccessful()
+        ->assertJsonPath('data.has_read_today', true)
+        ->assertJsonPath('data.current_streak', 3)
+        ->assertJsonPath('data.longest_streak', 3)
+        ->assertJsonPath('data.this_week_days', 1)
+        ->assertJsonPath('data.this_month_days', 3)
+        ->assertJsonPath('data.activity.11', ['date' => '2026-08-07', 'count' => 1])
+        ->assertJsonPath('data.activity.12', ['date' => '2026-08-08', 'count' => 1])
+        ->assertJsonPath('data.activity.13', ['date' => '2026-08-09', 'count' => 2]);
+
+    expect(Cache::has("user_dashboard_stats_{$user->id}"))->toBeTrue()
+        ->and(Cache::has("user_recent_reading_activity_series_{$user->id}"))->toBeTrue();
+});
+
+function createBootstrapReading(
+    User $user,
+    int $bookId,
+    string $dateRead,
+    string $createdAt,
+    int $chapter = 1,
+): ReadingLog {
+    return ReadingLog::factory()->for($user)->create([
+        'book_id' => $bookId,
+        'chapter' => $chapter,
+        'passage_text' => "Book {$bookId} {$chapter}",
+        'date_read' => $dateRead,
+        'created_at' => $createdAt,
+        'updated_at' => $createdAt,
+    ]);
+}

--- a/tests/Feature/Api/V1/MobileBootstrapTest.php
+++ b/tests/Feature/Api/V1/MobileBootstrapTest.php
@@ -5,9 +5,14 @@ use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Cache;
 
+const MOBILE_BOOTSTRAP_ENDPOINT = '/api/v1/bootstrap';
+const MOBILE_BOOTSTRAP_TODAY = '2026-08-09';
+const MOBILE_BOOTSTRAP_YESTERDAY = '2026-08-08';
+const MOBILE_BOOTSTRAP_TWO_DAYS_AGO = '2026-08-07';
+
 beforeEach(function (): void {
     Cache::flush();
-    Carbon::setTestNow(Carbon::parse('2026-08-09 00:30:00', config('app.timezone')));
+    Carbon::setTestNow(Carbon::parse(MOBILE_BOOTSTRAP_TODAY.' 00:30:00', config('app.timezone')));
 });
 
 afterEach(function (): void {
@@ -16,13 +21,13 @@ afterEach(function (): void {
 });
 
 it('requires a Sanctum token with the mobile ability', function (): void {
-    $this->getJson('/api/v1/bootstrap')->assertUnauthorized();
+    $this->getJson(MOBILE_BOOTSTRAP_ENDPOINT)->assertUnauthorized();
 
     $user = User::factory()->create();
     $token = $user->createToken('Reporting integration', ['reporting'])->plainTextToken;
 
     $this->withToken($token)
-        ->getJson('/api/v1/bootstrap')
+        ->getJson(MOBILE_BOOTSTRAP_ENDPOINT)
         ->assertForbidden();
 });
 
@@ -31,13 +36,13 @@ it('returns complete zero-filled bootstrap data in the application timezone', fu
     $token = $user->createToken('Pixel', ['mobile'])->plainTextToken;
 
     $response = $this->withToken($token)
-        ->getJson('/api/v1/bootstrap')
+        ->getJson(MOBILE_BOOTSTRAP_ENDPOINT)
         ->assertSuccessful()
         ->assertJsonPath('data.user.id', $user->id)
         ->assertJsonPath('data.user.name', $user->name)
         ->assertJsonPath('data.user.email', $user->email)
-        ->assertJsonPath('data.today', '2026-08-09')
-        ->assertJsonPath('data.yesterday', '2026-08-08')
+        ->assertJsonPath('data.today', MOBILE_BOOTSTRAP_TODAY)
+        ->assertJsonPath('data.yesterday', MOBILE_BOOTSTRAP_YESTERDAY)
         ->assertJsonPath('data.recent_book_ids', [])
         ->assertJsonPath('data.has_read_today', false)
         ->assertJsonPath('data.current_streak', 0)
@@ -65,7 +70,7 @@ it('returns complete zero-filled bootstrap data in the application timezone', fu
     expect($response->json('data.activity'))
         ->toHaveCount(14)
         ->and($response->json('data.activity.0'))->toBe(['date' => '2026-07-27', 'count' => 0])
-        ->and($response->json('data.activity.13'))->toBe(['date' => '2026-08-09', 'count' => 0]);
+        ->and($response->json('data.activity.13'))->toBe(['date' => MOBILE_BOOTSTRAP_TODAY, 'count' => 0]);
 });
 
 it('returns exactly the dates accepted by web reading validation', function (): void {
@@ -73,7 +78,7 @@ it('returns exactly the dates accepted by web reading validation', function (): 
     $token = $user->createToken('Pixel', ['mobile'])->plainTextToken;
 
     $dates = $this->withToken($token)
-        ->getJson('/api/v1/bootstrap')
+        ->getJson(MOBILE_BOOTSTRAP_ENDPOINT)
         ->assertSuccessful()
         ->json('data');
 
@@ -101,14 +106,14 @@ it('returns exactly the dates accepted by web reading validation', function (): 
 it('returns canon-aware books and filters recent books before limiting', function (): void {
     $user = User::factory()->create();
 
-    createBootstrapReading($user, 67, '2026-08-09', '2026-08-09 00:20:00');
-    createBootstrapReading($user, 1, '2026-08-08', '2026-08-08 12:00:00');
-    createBootstrapReading($user, 40, '2026-08-07', '2026-08-07 12:00:00');
+    createBootstrapReading($user, 67, MOBILE_BOOTSTRAP_TODAY, MOBILE_BOOTSTRAP_TODAY.' 00:20:00');
+    createBootstrapReading($user, 1, MOBILE_BOOTSTRAP_YESTERDAY, MOBILE_BOOTSTRAP_YESTERDAY.' 12:00:00');
+    createBootstrapReading($user, 40, MOBILE_BOOTSTRAP_TWO_DAYS_AGO, MOBILE_BOOTSTRAP_TWO_DAYS_AGO.' 12:00:00');
     createBootstrapReading($user, 43, '2026-08-06', '2026-08-06 12:00:00');
     createBootstrapReading($user, 19, '2026-08-05', '2026-08-05 12:00:00');
 
     $standardResponse = $this->withToken($user->createToken('Pixel', ['mobile'])->plainTextToken)
-        ->getJson('/api/v1/bootstrap')
+        ->getJson(MOBILE_BOOTSTRAP_ENDPOINT)
         ->assertSuccessful()
         ->assertJsonCount(66, 'data.books')
         ->assertJsonPath('data.recent_book_ids', [1, 40, 43]);
@@ -121,7 +126,7 @@ it('returns canon-aware books and filters recent books before limiting', functio
     $this->app['auth']->forgetGuards();
 
     $deuterocanonicalResponse = $this->withToken($user->createToken('Catholic Pixel', ['mobile'])->plainTextToken)
-        ->getJson('/api/v1/bootstrap')
+        ->getJson(MOBILE_BOOTSTRAP_ENDPOINT)
         ->assertSuccessful()
         ->assertJsonCount(73, 'data.books')
         ->assertJsonPath('data.recent_book_ids', [67, 1, 40]);
@@ -133,22 +138,22 @@ it('returns canon-aware books and filters recent books before limiting', functio
 it('returns the existing dashboard statistics and fourteen-day activity counts', function (): void {
     $user = User::factory()->create();
 
-    createBootstrapReading($user, 1, '2026-08-07', '2026-08-07 08:00:00');
-    createBootstrapReading($user, 1, '2026-08-08', '2026-08-08 08:00:00', 2);
-    createBootstrapReading($user, 1, '2026-08-09', '2026-08-09 00:10:00', 3);
-    createBootstrapReading($user, 40, '2026-08-09', '2026-08-09 00:20:00');
+    createBootstrapReading($user, 1, MOBILE_BOOTSTRAP_TWO_DAYS_AGO, MOBILE_BOOTSTRAP_TWO_DAYS_AGO.' 08:00:00');
+    createBootstrapReading($user, 1, MOBILE_BOOTSTRAP_YESTERDAY, MOBILE_BOOTSTRAP_YESTERDAY.' 08:00:00', 2);
+    createBootstrapReading($user, 1, MOBILE_BOOTSTRAP_TODAY, MOBILE_BOOTSTRAP_TODAY.' 00:10:00', 3);
+    createBootstrapReading($user, 40, MOBILE_BOOTSTRAP_TODAY, MOBILE_BOOTSTRAP_TODAY.' 00:20:00');
 
     $this->withToken($user->createToken('Pixel', ['mobile'])->plainTextToken)
-        ->getJson('/api/v1/bootstrap')
+        ->getJson(MOBILE_BOOTSTRAP_ENDPOINT)
         ->assertSuccessful()
         ->assertJsonPath('data.has_read_today', true)
         ->assertJsonPath('data.current_streak', 3)
         ->assertJsonPath('data.longest_streak', 3)
         ->assertJsonPath('data.this_week_days', 1)
         ->assertJsonPath('data.this_month_days', 3)
-        ->assertJsonPath('data.activity.11', ['date' => '2026-08-07', 'count' => 1])
-        ->assertJsonPath('data.activity.12', ['date' => '2026-08-08', 'count' => 1])
-        ->assertJsonPath('data.activity.13', ['date' => '2026-08-09', 'count' => 2]);
+        ->assertJsonPath('data.activity.11', ['date' => MOBILE_BOOTSTRAP_TWO_DAYS_AGO, 'count' => 1])
+        ->assertJsonPath('data.activity.12', ['date' => MOBILE_BOOTSTRAP_YESTERDAY, 'count' => 1])
+        ->assertJsonPath('data.activity.13', ['date' => MOBILE_BOOTSTRAP_TODAY, 'count' => 2]);
 
     expect(Cache::has("user_dashboard_stats_{$user->id}"))->toBeTrue()
         ->and(Cache::has("user_recent_reading_activity_series_{$user->id}"))->toBeTrue();

--- a/tests/Feature/Api/V1/MobileBootstrapTest.php
+++ b/tests/Feature/Api/V1/MobileBootstrapTest.php
@@ -195,7 +195,7 @@ function createBootstrapReading(
     string $createdAt,
     int $chapter = 1,
 ): ReadingLog {
-    return ReadingLog::factory()->for($user)->createOne([
+    $readingLog = ReadingLog::factory()->for($user)->createOne([
         'book_id' => $bookId,
         'chapter' => $chapter,
         'passage_text' => "Book {$bookId} {$chapter}",
@@ -203,4 +203,8 @@ function createBootstrapReading(
         'created_at' => $createdAt,
         'updated_at' => $createdAt,
     ]);
+
+    assert($readingLog instanceof ReadingLog);
+
+    return $readingLog;
 }


### PR DESCRIPTION
## Problem

The native Home and Log screens need a single authenticated bootstrap payload sourced from Laravel's existing canon, reading-form, date, and statistics behavior.

## Implementation

- add `GET /api/v1/bootstrap` protected by Sanctum and the `mobile` ability
- return current user identity, server-owned Today/Yesterday dates, canon-aware books, three valid recent-book IDs, read-today state, streak/week/month statistics, and a zero-filled 14-day activity series
- reuse `BibleReferenceService`, `ReadingFormService`, and the existing day-bounded `UserStatisticsService` statistic paths so the controller does not duplicate calculations or serve previous-day data after midnight
- add focused Pest coverage for authorization, timezone/date parity with web validation, both canon modes, recent-book filtering, empty users, statistics, activity counts, cache use, and the midnight boundary

## Verification

- `php artisan test --compact tests/Feature/Api/V1/MobileBootstrapTest.php` — 6 passed, 365 assertions
- relevant service regression suite — 37 passed, 125 assertions
- `php artisan test --compact` — 684 passed, 1 skipped, 24,483 assertions
- `vendor/bin/pint --dirty --format agent`
- `php artisan route:list --path=api/v1/bootstrap -v`
- `git diff --check`

## Documentation consulted

- Delight Mobile V1 Contract (Linear)
- DEL-275 acceptance criteria (Linear)
- Laravel 12/Sanctum API token ability, JSON testing, validation assertion, and cache-expiration documentation via Laravel Boost

## UI evidence

Not applicable; this PR adds a JSON API endpoint only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an authenticated mobile bootstrap endpoint providing user details, reading dates, Bible books, recent books, reading status, statistics, streaks, summaries, and recent activity.
  * Added support for mobile-token authorization when accessing bootstrap data.
  * Added timezone-aware reading information, including date validation and zero-filled results where applicable.

* **Bug Fixes**
  * Improved handling of reading data across midnight and activity tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->