### PR TITLE
[DEL-277] Add mobile reading creation and history APIs

### DIFF
--- a/app/Http/Controllers/Api/V1/ReadingLogController.php
+++ b/app/Http/Controllers/Api/V1/ReadingLogController.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\V1\StoreReadingLogRequest;
+use App\Http\Resources\Api\V1\ReadingLogDayResource;
+use App\Http\Resources\Api\V1\ReadingLogGroupResource;
+use App\Services\ReadingLogService;
+use App\Services\UserStatisticsService;
+use Illuminate\Database\QueryException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Validation\ValidationException;
+
+class ReadingLogController extends Controller
+{
+    public function __construct(
+        private ReadingLogService $readingLogService,
+        private UserStatisticsService $userStatisticsService
+    ) {}
+
+    public function store(StoreReadingLogRequest $request): JsonResponse
+    {
+        $data = $request->validated();
+        $startChapter = (int) $data['start_chapter'];
+        $endChapter = isset($data['end_chapter']) ? (int) $data['end_chapter'] : $startChapter;
+
+        if ($startChapter === $endChapter) {
+            $data['chapter'] = $startChapter;
+        } else {
+            $data['chapters'] = range($startChapter, $endChapter);
+        }
+
+        try {
+            $result = $this->readingLogService->logReadingWithResult($request->user(), $data);
+        } catch (QueryException $exception) {
+            if ($exception->getCode() !== '23000') {
+                throw $exception;
+            }
+
+            throw ValidationException::withMessages([
+                'start_chapter' => ['One or more of these chapters have already been logged for this date.'],
+            ]);
+        }
+
+        $group = $this->readingLogService
+            ->getPreparedLogsForDate($request->user(), $data['date_read'], $this->userStatisticsService)
+            ?->first(fn ($log): bool => $log->all_logs->contains('id', $result->log->id));
+
+        abort_if($group === null, 500, 'The created reading group could not be loaded.');
+
+        return (new ReadingLogGroupResource($group))
+            ->response()
+            ->setStatusCode(201);
+    }
+
+    public function index(Request $request): AnonymousResourceCollection
+    {
+        $logs = $this->readingLogService->getPaginatedDayGroupsFor(
+            $request,
+            $this->userStatisticsService,
+            path: $request->url()
+        );
+        $logs->setCollection($logs->getCollection()->values());
+
+        return ReadingLogDayResource::collection($logs);
+    }
+}

--- a/app/Http/Requests/Api/V1/StoreReadingLogRequest.php
+++ b/app/Http/Requests/Api/V1/StoreReadingLogRequest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Http\Requests\Api\V1;
+
+use App\Services\BibleReferenceService;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
+
+class StoreReadingLogRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(BibleReferenceService $bibleReferenceService): array
+    {
+        $allowedBookIds = collect($bibleReferenceService->listBibleBooks(
+            includeDeuterocanonical: $this->user()->includesDeuterocanonicalBooks()
+        ))->pluck('id')->all();
+
+        return [
+            'book_id' => ['required', 'integer', Rule::in($allowedBookIds)],
+            'start_chapter' => ['required', 'integer', 'min:1'],
+            'end_chapter' => ['nullable', 'integer', 'min:1'],
+            'date_read' => [
+                'required',
+                'date_format:Y-m-d',
+                Rule::in([today()->toDateString(), today()->subDay()->toDateString()]),
+            ],
+            'notes_text' => ['nullable', 'string', 'max:1000'],
+        ];
+    }
+
+    /**
+     * Get the validation error messages for the request.
+     *
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'book_id.in' => 'The selected book is not available for your Bible canon.',
+            'start_chapter.min' => 'The start chapter must be at least 1.',
+            'end_chapter.min' => 'The end chapter must be at least 1.',
+            'date_read.in' => 'The reading date must be today or yesterday.',
+            'notes_text.max' => 'The notes may not be greater than 1,000 characters.',
+        ];
+    }
+
+    /**
+     * Perform chapter validation after the base field rules pass.
+     *
+     * @return array<int, callable(Validator): void>
+     */
+    public function after(): array
+    {
+        return [
+            function (Validator $validator): void {
+                if ($validator->errors()->hasAny(['book_id', 'start_chapter', 'end_chapter'])) {
+                    return;
+                }
+
+                $bookId = (int) $this->input('book_id');
+                $startChapter = (int) $this->input('start_chapter');
+                $endChapter = $this->filled('end_chapter')
+                    ? (int) $this->input('end_chapter')
+                    : $startChapter;
+                $includeDeuterocanonical = $this->user()->includesDeuterocanonicalBooks();
+                $bibleReferenceService = $this->container->make(BibleReferenceService::class);
+
+                if ($startChapter > $endChapter) {
+                    $validator->errors()->add('end_chapter', 'The end chapter must be greater than or equal to the start chapter.');
+
+                    return;
+                }
+
+                if (! $bibleReferenceService->validateChapterNumber($bookId, $startChapter, $includeDeuterocanonical)) {
+                    $validator->errors()->add('start_chapter', 'The start chapter is invalid for the selected book.');
+                }
+
+                if (! $bibleReferenceService->validateChapterNumber($bookId, $endChapter, $includeDeuterocanonical)) {
+                    $validator->errors()->add('end_chapter', 'The end chapter is invalid for the selected book.');
+                }
+            },
+        ];
+    }
+}

--- a/app/Http/Resources/Api/V1/ReadingLogDayResource.php
+++ b/app/Http/Resources/Api/V1/ReadingLogDayResource.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Resources\Api\V1;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ReadingLogDayResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'date_read' => $this->resource->first()->date_read->toDateString(),
+            'groups' => ReadingLogGroupResource::collection($this->resource),
+        ];
+    }
+}

--- a/app/Http/Resources/Api/V1/ReadingLogGroupResource.php
+++ b/app/Http/Resources/Api/V1/ReadingLogGroupResource.php
@@ -24,7 +24,7 @@ class ReadingLogGroupResource extends JsonResource
         $endChapter = (int) $logs->max('chapter');
         $bookName = app(BibleReferenceService::class)->getLocalizedBookName(
             $firstLog->book_id,
-            includeDeuterocanonical: $request->user()->includesDeuterocanonicalBooks()
+            includeDeuterocanonical: true
         );
 
         return [

--- a/app/Http/Resources/Api/V1/ReadingLogGroupResource.php
+++ b/app/Http/Resources/Api/V1/ReadingLogGroupResource.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Models\ReadingLog;
+use App\Services\BibleReferenceService;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Collection;
+
+class ReadingLogGroupResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var Collection<int, ReadingLog> $logs */
+        $logs = $this->resource->all_logs ?? collect([$this->resource]);
+        $firstLog = $logs->first();
+        $startChapter = (int) $logs->min('chapter');
+        $endChapter = (int) $logs->max('chapter');
+        $bookName = app(BibleReferenceService::class)->getLocalizedBookName(
+            $firstLog->book_id,
+            includeDeuterocanonical: $request->user()->includesDeuterocanonicalBooks()
+        );
+
+        return [
+            'log_ids' => $logs->pluck('id')->map(fn ($id): int => (int) $id)->values(),
+            'book' => [
+                'id' => (int) $firstLog->book_id,
+                'name' => $bookName,
+            ],
+            'start_chapter' => $startChapter,
+            'end_chapter' => $endChapter === $startChapter ? null : $endChapter,
+            'passage' => $this->resource->display_passage_text ?? $firstLog->passage_text,
+            'notes_text' => $firstLog->notes_text,
+            'date_read' => $firstLog->date_read->toDateString(),
+            'logged_at' => $firstLog->created_at->toISOString(),
+        ];
+    }
+}

--- a/app/Services/ReadingLogService.php
+++ b/app/Services/ReadingLogService.php
@@ -6,6 +6,7 @@ use App\Enums\OnboardingStep;
 use App\Models\ChurnRecoveryCampaign;
 use App\Models\ReadingLog;
 use App\Models\User;
+use App\Models\UserAchievement;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Pagination\LengthAwarePaginator;
@@ -44,6 +45,13 @@ class ReadingLogService
      * Log a new Bible reading entry and return the log with any achievements unlocked by it.
      */
     public function logReadingWithResult(User $user, array $data, bool $evaluateAchievements = true): ReadingLogResult
+    {
+        return DB::transaction(
+            fn (): ReadingLogResult => $this->persistReadingWithResult($user, $data, $evaluateAchievements)
+        );
+    }
+
+    private function persistReadingWithResult(User $user, array $data, bool $evaluateAchievements): ReadingLogResult
     {
         // Validate and format the Bible reference
         $includeDeuterocanonical = $user->includesDeuterocanonicalBooks();
@@ -137,7 +145,7 @@ class ReadingLogService
     }
 
     /**
-     * @return array{awarded: int, skipped_duplicates: int, would_award: int, candidates: Collection<int, array<string, mixed>>, awarded_achievements: Collection<int, \App\Models\UserAchievement>}
+     * @return array{awarded: int, skipped_duplicates: int, would_award: int, candidates: Collection<int, array<string, mixed>>, awarded_achievements: Collection<int, UserAchievement>}
      */
     public function evaluateAchievements(User $user): array
     {
@@ -145,7 +153,7 @@ class ReadingLogService
     }
 
     /**
-     * @return array{awarded: int, skipped_duplicates: int, would_award: int, candidates: Collection<int, array<string, mixed>>, awarded_achievements: Collection<int, \App\Models\UserAchievement>}
+     * @return array{awarded: int, skipped_duplicates: int, would_award: int, candidates: Collection<int, array<string, mixed>>, awarded_achievements: Collection<int, UserAchievement>}
      */
     private function handlePostLogSideEffects(User $user, bool $isFirstReadingOfDay, string $loggedDate, bool $evaluateAchievements = true): array
     {
@@ -173,15 +181,19 @@ class ReadingLogService
     {
         $chapters = $data['chapters'];
         $firstLog = null;
+        $loggedAt = now();
 
         foreach ($chapters as $chapter) {
-            $readingLog = $user->readingLogs()->create([
+            $readingLog = new ReadingLog([
                 'book_id' => $data['book_id'],
                 'chapter' => $chapter,
                 'passage_text' => $data['passage_text'], // Range text like "John 1-3"
                 'date_read' => $dateRead,
                 'notes_text' => $data['notes_text'] ?? null,
             ]);
+            $readingLog->setCreatedAt($loggedAt);
+            $readingLog->setUpdatedAt($loggedAt);
+            $user->readingLogs()->save($readingLog);
 
             // Update book progress for each chapter
             $this->updateBookProgress($user, $data['book_id'], $chapter, $includeDeuterocanonical);
@@ -683,11 +695,15 @@ class ReadingLogService
         ])->render();
     }
 
-    public function getPaginatedDayGroupsFor(Request $request, UserStatisticsService $statisticsService, int $perPage = 8): LengthAwarePaginator
-    {
+    public function getPaginatedDayGroupsFor(
+        Request $request,
+        UserStatisticsService $statisticsService,
+        int $perPage = 8,
+        ?string $path = null
+    ): LengthAwarePaginator {
         $user = $request->user();
         $currentPage = max(1, (int) $request->get('page', 1));
-        $basePath = $request->routeIs('logs.index') ? $request->url() : route('logs.index');
+        $basePath = $path ?? ($request->routeIs('logs.index') ? $request->url() : route('logs.index'));
 
         // Step 1: Paginate the unique dates first
         // This is much more efficient than loading all logs into memory

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Api\V1\MobileBootstrapController;
 use App\Http\Controllers\Api\V1\MobileTokenController;
+use App\Http\Controllers\Api\V1\ReadingLogController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -31,5 +32,11 @@ Route::prefix('v1')->name('api.v1.')->group(function (): void {
 
         Route::get('/bootstrap', MobileBootstrapController::class)
             ->name('bootstrap');
+
+        Route::post('/reading-logs', [ReadingLogController::class, 'store'])
+            ->name('reading-logs.store');
+
+        Route::get('/reading-logs', [ReadingLogController::class, 'index'])
+            ->name('reading-logs.index');
     });
 });

--- a/tests/Feature/Api/V1/MobileReadingLogApiTest.php
+++ b/tests/Feature/Api/V1/MobileReadingLogApiTest.php
@@ -7,6 +7,8 @@ use App\Models\ReadingLog;
 use App\Models\User;
 use Carbon\Carbon;
 
+const MOBILE_READING_LOGS_ENDPOINT = '/api/v1/reading-logs';
+
 function mobileReadingToken(User $user, array $abilities = ['mobile']): string
 {
     return $user->createToken('Mobile API test', $abilities)->plainTextToken;
@@ -19,19 +21,19 @@ beforeEach(function () {
 it('requires a mobile token ability for creation and history', function () {
     $user = User::factory()->create();
 
-    $this->postJson('/api/v1/reading-logs', [])->assertUnauthorized();
-    $this->getJson('/api/v1/reading-logs')->assertUnauthorized();
+    $this->postJson(MOBILE_READING_LOGS_ENDPOINT, [])->assertUnauthorized();
+    $this->getJson(MOBILE_READING_LOGS_ENDPOINT)->assertUnauthorized();
 
     $token = mobileReadingToken($user, ['reporting']);
 
-    $this->withToken($token)->postJson('/api/v1/reading-logs', [])->assertForbidden();
-    $this->withToken($token)->getJson('/api/v1/reading-logs')->assertForbidden();
+    $this->withToken($token)->postJson(MOBILE_READING_LOGS_ENDPOINT, [])->assertForbidden();
+    $this->withToken($token)->getJson(MOBILE_READING_LOGS_ENDPOINT)->assertForbidden();
 });
 
 it('creates a single chapter and returns its canonical group', function () {
     $user = User::factory()->create();
 
-    $response = $this->withToken(mobileReadingToken($user))->postJson('/api/v1/reading-logs', [
+    $response = $this->withToken(mobileReadingToken($user))->postJson(MOBILE_READING_LOGS_ENDPOINT, [
         'book_id' => 43,
         'start_chapter' => 3,
         'end_chapter' => null,
@@ -61,7 +63,7 @@ it('creates a single chapter and returns its canonical group', function () {
 it('creates a chapter range atomically with book progress', function () {
     $user = User::factory()->create();
 
-    $this->withToken(mobileReadingToken($user))->postJson('/api/v1/reading-logs', [
+    $this->withToken(mobileReadingToken($user))->postJson(MOBILE_READING_LOGS_ENDPOINT, [
         'book_id' => 43,
         'start_chapter' => 1,
         'end_chapter' => 3,
@@ -89,7 +91,7 @@ it('returns field-specific validation errors', function (array $overrides, strin
     ];
 
     $this->withToken(mobileReadingToken($user))
-        ->postJson('/api/v1/reading-logs', array_replace($payload, $overrides))
+        ->postJson(MOBILE_READING_LOGS_ENDPOINT, array_replace($payload, $overrides))
         ->assertUnprocessable()
         ->assertJsonValidationErrors($field);
 })->with([
@@ -108,7 +110,7 @@ it('allows a deuterocanonical book only when enabled for the user', function () 
         'deuterocanonical_books_enabled_at' => now(),
     ]);
 
-    $this->withToken(mobileReadingToken($user))->postJson('/api/v1/reading-logs', [
+    $this->withToken(mobileReadingToken($user))->postJson(MOBILE_READING_LOGS_ENDPOINT, [
         'book_id' => 67,
         'start_chapter' => 1,
         'date_read' => today()->toDateString(),
@@ -125,7 +127,7 @@ it('rolls back earlier logs and progress when a range fails partway through', fu
         'date_read' => today()->toDateString(),
     ]);
 
-    $this->withToken(mobileReadingToken($user))->postJson('/api/v1/reading-logs', [
+    $this->withToken(mobileReadingToken($user))->postJson(MOBILE_READING_LOGS_ENDPOINT, [
         'book_id' => 43,
         'start_chapter' => 1,
         'end_chapter' => 2,
@@ -176,7 +178,7 @@ it('returns only the users history newest first grouped by date session and cont
         'date_read' => today()->toDateString(),
     ]);
 
-    $pageOne = $this->withToken(mobileReadingToken($user))->getJson('/api/v1/reading-logs?page=1');
+    $pageOne = $this->withToken(mobileReadingToken($user))->getJson(MOBILE_READING_LOGS_ENDPOINT.'?page=1');
 
     $pageOne
         ->assertSuccessful()
@@ -194,7 +196,7 @@ it('returns only the users history newest first grouped by date session and cont
     expect(collect($pageOne->json('data'))->pluck('groups')->flatten(1)->pluck('log_ids')->flatten())
         ->not->toContain($otherLog->id);
 
-    $this->withToken(mobileReadingToken($user))->getJson('/api/v1/reading-logs?page=2')
+    $this->withToken(mobileReadingToken($user))->getJson(MOBILE_READING_LOGS_ENDPOINT.'?page=2')
         ->assertSuccessful()
         ->assertJsonCount(1, 'data')
         ->assertJsonPath('data.0.date_read', today()->subDays(8)->toDateString());
@@ -216,7 +218,7 @@ it('keeps web and api domain side effects in parity', function () {
         'notes_text' => 'Shared domain path.',
     ];
 
-    $this->withToken(mobileReadingToken($apiUser))->postJson('/api/v1/reading-logs', $payload)->assertCreated();
+    $this->withToken(mobileReadingToken($apiUser))->postJson(MOBILE_READING_LOGS_ENDPOINT, $payload)->assertCreated();
     $this->actingAs($webUser)->post(route('logs.store'), $payload)->assertSuccessful();
 
     $domainState = function (User $user, ChurnRecoveryCampaign $campaign): array {

--- a/tests/Feature/Api/V1/MobileReadingLogApiTest.php
+++ b/tests/Feature/Api/V1/MobileReadingLogApiTest.php
@@ -1,0 +1,241 @@
+<?php
+
+use App\Enums\OnboardingStep;
+use App\Models\BookProgress;
+use App\Models\ChurnRecoveryCampaign;
+use App\Models\ReadingLog;
+use App\Models\User;
+use Carbon\Carbon;
+
+function mobileReadingToken(User $user, array $abilities = ['mobile']): string
+{
+    return $user->createToken('Mobile API test', $abilities)->plainTextToken;
+}
+
+beforeEach(function () {
+    $this->travelTo(Carbon::parse('2026-08-08 12:00:00'));
+});
+
+it('requires a mobile token ability for creation and history', function () {
+    $user = User::factory()->create();
+
+    $this->postJson('/api/v1/reading-logs', [])->assertUnauthorized();
+    $this->getJson('/api/v1/reading-logs')->assertUnauthorized();
+
+    $token = mobileReadingToken($user, ['reporting']);
+
+    $this->withToken($token)->postJson('/api/v1/reading-logs', [])->assertForbidden();
+    $this->withToken($token)->getJson('/api/v1/reading-logs')->assertForbidden();
+});
+
+it('creates a single chapter and returns its canonical group', function () {
+    $user = User::factory()->create();
+
+    $response = $this->withToken(mobileReadingToken($user))->postJson('/api/v1/reading-logs', [
+        'book_id' => 43,
+        'start_chapter' => 3,
+        'end_chapter' => null,
+        'date_read' => today()->toDateString(),
+        'notes_text' => 'Born of the Spirit.',
+    ]);
+
+    $response
+        ->assertCreated()
+        ->assertJsonPath('data.book.id', 43)
+        ->assertJsonPath('data.book.name', 'John')
+        ->assertJsonPath('data.start_chapter', 3)
+        ->assertJsonPath('data.end_chapter', null)
+        ->assertJsonPath('data.passage', 'John 3')
+        ->assertJsonPath('data.notes_text', 'Born of the Spirit.')
+        ->assertJsonPath('data.date_read', today()->toDateString())
+        ->assertJsonCount(1, 'data.log_ids')
+        ->assertJsonStructure(['data' => ['logged_at']]);
+
+    expect($user->readingLogs()
+        ->where('book_id', 43)
+        ->where('chapter', 3)
+        ->whereDate('date_read', today())
+        ->exists())->toBeTrue();
+});
+
+it('creates a chapter range atomically with book progress', function () {
+    $user = User::factory()->create();
+
+    $this->withToken(mobileReadingToken($user))->postJson('/api/v1/reading-logs', [
+        'book_id' => 43,
+        'start_chapter' => 1,
+        'end_chapter' => 3,
+        'date_read' => today()->subDay()->toDateString(),
+        'notes_text' => null,
+    ])
+        ->assertCreated()
+        ->assertJsonPath('data.start_chapter', 1)
+        ->assertJsonPath('data.end_chapter', 3)
+        ->assertJsonPath('data.passage', 'John 1-3')
+        ->assertJsonCount(3, 'data.log_ids');
+
+    expect($user->readingLogs()->orderBy('chapter')->pluck('chapter')->all())->toBe([1, 2, 3])
+        ->and($user->bookProgress()->where('book_id', 43)->firstOrFail()->chapters_read)->toBe([1, 2, 3]);
+});
+
+it('returns field-specific validation errors', function (array $overrides, string $field) {
+    $user = User::factory()->create();
+    $payload = [
+        'book_id' => 43,
+        'start_chapter' => 1,
+        'end_chapter' => null,
+        'date_read' => today()->toDateString(),
+        'notes_text' => null,
+    ];
+
+    $this->withToken(mobileReadingToken($user))
+        ->postJson('/api/v1/reading-logs', array_replace($payload, $overrides))
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors($field);
+})->with([
+    'unknown book' => [['book_id' => 999], 'book_id'],
+    'book outside Protestant canon' => [['book_id' => 67], 'book_id'],
+    'invalid start chapter' => [['start_chapter' => 22], 'start_chapter'],
+    'invalid end chapter' => [['end_chapter' => 22], 'end_chapter'],
+    'inverted range' => [['start_chapter' => 3, 'end_chapter' => 2], 'end_chapter'],
+    'date older than yesterday' => [['date_read' => '2026-08-06'], 'date_read'],
+    'date with a non-canonical format' => [['date_read' => today()->format('m/d/Y')], 'date_read'],
+    'notes over one thousand characters' => [['notes_text' => str_repeat('a', 1001)], 'notes_text'],
+]);
+
+it('allows a deuterocanonical book only when enabled for the user', function () {
+    $user = User::factory()->create([
+        'deuterocanonical_books_enabled_at' => now(),
+    ]);
+
+    $this->withToken(mobileReadingToken($user))->postJson('/api/v1/reading-logs', [
+        'book_id' => 67,
+        'start_chapter' => 1,
+        'date_read' => today()->toDateString(),
+    ])->assertCreated();
+});
+
+it('rolls back earlier logs and progress when a range fails partway through', function () {
+    $user = User::factory()->create([
+        'celebrated_first_reading_at' => now()->subDay(),
+    ]);
+    ReadingLog::factory()->for($user)->create([
+        'book_id' => 43,
+        'chapter' => 2,
+        'date_read' => today()->toDateString(),
+    ]);
+
+    $this->withToken(mobileReadingToken($user))->postJson('/api/v1/reading-logs', [
+        'book_id' => 43,
+        'start_chapter' => 1,
+        'end_chapter' => 2,
+        'date_read' => today()->toDateString(),
+    ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors('start_chapter');
+
+    expect($user->readingLogs()
+        ->where('book_id', 43)
+        ->where('chapter', 1)
+        ->whereDate('date_read', today())
+        ->exists())->toBeFalse();
+    $this->assertDatabaseMissing('book_progress', [
+        'user_id' => $user->id,
+        'book_id' => 43,
+    ]);
+});
+
+it('returns only the users history newest first grouped by date session and contiguous chapters', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+    $sessionTime = now()->subHour();
+
+    foreach ([1, 2, 4] as $chapter) {
+        ReadingLog::factory()->for($user)->create([
+            'book_id' => 43,
+            'chapter' => $chapter,
+            'date_read' => today()->toDateString(),
+            'created_at' => $sessionTime,
+            'updated_at' => $sessionTime,
+        ]);
+    }
+
+    foreach (range(1, 8) as $offset) {
+        ReadingLog::factory()->for($user)->create([
+            'book_id' => 43,
+            'chapter' => $offset + 10,
+            'date_read' => today()->subDays($offset)->toDateString(),
+            'created_at' => $sessionTime->copy()->subDays($offset),
+            'updated_at' => $sessionTime->copy()->subDays($offset),
+        ]);
+    }
+
+    $otherLog = ReadingLog::factory()->for($otherUser)->create([
+        'book_id' => 43,
+        'chapter' => 10,
+        'date_read' => today()->toDateString(),
+    ]);
+
+    $pageOne = $this->withToken(mobileReadingToken($user))->getJson('/api/v1/reading-logs?page=1');
+
+    $pageOne
+        ->assertSuccessful()
+        ->assertJsonCount(8, 'data')
+        ->assertJsonPath('data.0.date_read', today()->toDateString())
+        ->assertJsonPath('data.0.groups.0.start_chapter', 1)
+        ->assertJsonPath('data.0.groups.0.end_chapter', 2)
+        ->assertJsonPath('data.0.groups.0.passage', 'John 1-2')
+        ->assertJsonPath('data.0.groups.1.start_chapter', 4)
+        ->assertJsonPath('meta.current_page', 1)
+        ->assertJsonPath('meta.last_page', 2)
+        ->assertJsonPath('meta.per_page', 8)
+        ->assertJsonPath('meta.total', 9);
+
+    expect(collect($pageOne->json('data'))->pluck('groups')->flatten(1)->pluck('log_ids')->flatten())
+        ->not->toContain($otherLog->id);
+
+    $this->withToken(mobileReadingToken($user))->getJson('/api/v1/reading-logs?page=2')
+        ->assertSuccessful()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.date_read', today()->subDays(8)->toDateString());
+});
+
+it('keeps web and api domain side effects in parity', function () {
+    $webUser = User::factory()->create();
+    $apiUser = User::factory()->create();
+    $campaignState = [
+        'started_at' => now()->subDay(),
+        'observed_until' => now()->addDays(6),
+    ];
+    $webCampaign = ChurnRecoveryCampaign::factory()->for($webUser)->create($campaignState);
+    $apiCampaign = ChurnRecoveryCampaign::factory()->for($apiUser)->create($campaignState);
+    $payload = [
+        'book_id' => 43,
+        'start_chapter' => 1,
+        'date_read' => today()->toDateString(),
+        'notes_text' => 'Shared domain path.',
+    ];
+
+    $this->withToken(mobileReadingToken($apiUser))->postJson('/api/v1/reading-logs', $payload)->assertCreated();
+    $this->actingAs($webUser)->post(route('logs.store'), $payload)->assertSuccessful();
+
+    $domainState = function (User $user, ChurnRecoveryCampaign $campaign): array {
+        return [
+            'readings' => $user->readingLogs()->orderBy('chapter')->get(['book_id', 'chapter', 'date_read', 'notes_text'])->toArray(),
+            'progress' => BookProgress::query()->where('user_id', $user->id)->firstOrFail()->only([
+                'book_id',
+                'chapters_read',
+                'completion_percent',
+                'is_completed',
+            ]),
+            'celebrated_first_reading' => $user->fresh()->celebrated_first_reading_at !== null,
+            'onboarding_steps' => $user->onboardingStepEvents()->pluck('step')->map->value->sort()->values()->all(),
+            'achievements' => $user->achievements()->orderBy('achievement_key')->pluck('achievement_key')->all(),
+            'campaign_reactivated' => $campaign->fresh()->reactivated_at !== null,
+            'campaign_completed' => $campaign->fresh()->completed_at !== null,
+        ];
+    };
+
+    expect($domainState($apiUser, $apiCampaign))->toBe($domainState($webUser, $webCampaign))
+        ->and($apiUser->onboardingStepEvents()->where('step', OnboardingStep::FirstReadingCompleted)->exists())->toBeTrue();
+});

--- a/tests/Feature/Api/V1/MobileReadingLogApiTest.php
+++ b/tests/Feature/Api/V1/MobileReadingLogApiTest.php
@@ -117,6 +117,27 @@ it('allows a deuterocanonical book only when enabled for the user', function () 
     ])->assertCreated();
 });
 
+it('keeps existing deuterocanonical history visible after the user disables it', function () {
+    $user = User::factory()->create([
+        'deuterocanonical_books_enabled_at' => now(),
+    ]);
+
+    ReadingLog::factory()->for($user)->create([
+        'book_id' => 67,
+        'chapter' => 1,
+        'passage_text' => 'Tobit 1',
+        'date_read' => today()->toDateString(),
+    ]);
+
+    $user->forceFill(['deuterocanonical_books_enabled_at' => null])->save();
+
+    $this->withToken(mobileReadingToken($user))->getJson(MOBILE_READING_LOGS_ENDPOINT)
+        ->assertSuccessful()
+        ->assertJsonPath('data.0.groups.0.book.id', 67)
+        ->assertJsonPath('data.0.groups.0.book.name', 'Tobit')
+        ->assertJsonPath('data.0.groups.0.passage', 'Tobit 1');
+});
+
 it('rolls back earlier logs and progress when a range fails partway through', function () {
     $user = User::factory()->create([
         'celebrated_first_reading_at' => now()->subDay(),


### PR DESCRIPTION
## Problem

The mobile MVP needs versioned, token-protected access to Delight’s existing reading creation and grouped history behavior without duplicating or weakening the web domain path.

## Implementation

- add `POST /api/v1/reading-logs` and `GET /api/v1/reading-logs`, protected by Sanctum and the `mobile` ability
- validate canon-aware books, chapter bounds/ranges, Today/Yesterday dates, and 1,000-character notes through a Form Request
- reuse the existing reading service for progress, statistics, onboarding, achievements, and churn-recovery side effects
- make reading creation transactional and keep one exact timestamp across multi-chapter ranges so failures roll back logs/progress and ranges remain one canonical session
- paginate distinct reading dates eight per page and serialize web-equivalent session/contiguous groups through API Resources

## Verification

- `DB_DATABASE=:memory: php artisan test --compact tests/Feature/Api/V1/MobileReadingLogApiTest.php` — 15 passed, 72 assertions
- focused API/web/domain regression lane — 59 passed, 275 assertions
- `DB_DATABASE=:memory: php artisan test --compact` — 693 passed, 1 skipped, 24,190 assertions
- `vendor/bin/pint --dirty --format agent`
- `npm run build`
- `php artisan route:list --path=api/v1/reading-logs`
- `git diff --cached --check`

## Scope references

- Linear issue: DEL-277
- Delight Mobile V1 Contract (canonical Linear document)
- Root `AGENTS.md`

No UI files changed, so screenshots are not applicable. No deployment, Laravel Cloud mutation, EAS build, release, or merge was performed.