### PR TITLE
Move chapter count pill from date header to passage label for multi-chapter readings

### DIFF
--- a/resources/views/components/bible/reading-log-card.blade.php
+++ b/resources/views/components/bible/reading-log-card.blade.php
@@ -13,8 +13,15 @@ $editModalId = "edit-note-{$log->id}";
     <div class="flex items-center justify-between gap-3">
         {{-- Passage and Time Info --}}
         <div class="flex-1 min-w-0">
-            <h3 class="text-base font-semibold text-gray-900 dark:text-white leading-tight mb-1">
-                {{ $log->display_passage_text ?? $log->passage_text }}
+            <h3 class="mb-1 flex items-center gap-2 text-base font-semibold leading-tight text-gray-900 dark:text-white">
+                <span>{{ $log->display_passage_text ?? $log->passage_text }}</span>
+                @if ($isMultiChapter)
+                    <span
+                        class="rounded-full bg-primary-100 px-2.5 py-0.5 text-xs font-medium text-primary-800 dark:bg-primary-800 dark:text-primary-200"
+                        aria-label="{{ $allLogs->count() }} chapters">
+                        {{ $allLogs->count() }}
+                    </span>
+                @endif
             </h3>
             <div class="text-xs text-gray-500 dark:text-gray-400">
                 Logged at {{ $log->created_at->format('g:i A') }}

--- a/resources/views/partials/reading-log-day.blade.php
+++ b/resources/views/partials/reading-log-day.blade.php
@@ -1,9 +1,5 @@
 @props(['date', 'logsForDay', 'swapMethod' => null])
 
-@php
-    $dayChapterCount = $logsForDay->sum(fn($log) => $log->chapters_count ?? ($log->all_logs?->count() ?? 1));
-@endphp
-
 <li id="reading-day-{{ $date }}" class="ms-6"
     @if ($swapMethod) hx-swap-oob="{{ $swapMethod }}" @endif>
     {{-- Timeline Dot Indicator --}}
@@ -11,17 +7,11 @@
         class="absolute w-3 h-3 bg-primary-500 rounded-full mt-1.5 -start-1.5 border-2 border-white dark:border-gray-900">
     </div>
 
-    {{-- Date Header with Reading Count Badge --}}
-    <div class="flex items-center gap-2 mb-4">
+    {{-- Date Header --}}
+    <div class="mb-4">
         <time class="text-sm font-semibold text-gray-900 dark:text-white">
             {{ \Carbon\Carbon::parse($date)->format('M j, Y') }}
         </time>
-        @if ($dayChapterCount > 0)
-            <span
-                class="bg-primary-100 text-primary-800 dark:bg-primary-800 dark:text-primary-200 text-xs font-medium px-2.5 py-0.5 rounded-full">
-                {{ $dayChapterCount }} chapter{{ $dayChapterCount > 1 ? 's' : '' }}
-            </span>
-        @endif
     </div>
 
     {{-- Individual Reading Cards for This Day --}}

--- a/tests/Feature/ReadingLogHistoryInfiniteScrollTest.php
+++ b/tests/Feature/ReadingLogHistoryInfiniteScrollTest.php
@@ -41,4 +41,42 @@ class ReadingLogHistoryInfiniteScrollTest extends TestCase
         $response->assertSee('hx-swap="outerHTML"', false);
         $response->assertSee('hx-swap-oob="beforeend"', false);
     }
+
+    public function test_chapter_count_badge_is_shown_beside_multi_chapter_passage_only(): void
+    {
+        $user = User::factory()->create();
+        $loggedAt = Carbon::today()->setTime(8, 0);
+
+        foreach ([1, 2] as $chapter) {
+            ReadingLog::factory()->create([
+                'user_id' => $user->id,
+                'book_id' => 1,
+                'chapter' => $chapter,
+                'passage_text' => 'Genesis '.$chapter,
+                'date_read' => $loggedAt->toDateString(),
+                'created_at' => $loggedAt,
+                'updated_at' => $loggedAt,
+            ]);
+        }
+
+        ReadingLog::factory()->create([
+            'user_id' => $user->id,
+            'book_id' => 2,
+            'chapter' => 1,
+            'passage_text' => 'Exodus 1',
+            'date_read' => $loggedAt->copy()->subDay()->toDateString(),
+            'created_at' => $loggedAt->copy()->subDay(),
+            'updated_at' => $loggedAt->copy()->subDay(),
+        ]);
+
+        $response = $this->actingAs($user)->get(route('logs.index'));
+
+        $response->assertOk();
+        $response->assertSee('aria-label="2 chapters"', false);
+        $response->assertDontSee('aria-label="1 chapter"', false);
+
+        expect($response->getContent())
+            ->toMatch('/<h3[^>]*>.*?aria-label="2 chapters".*?<\/h3>/s')
+            ->not->toMatch('/<div class="mb-4">\s*<time[^>]*>.*?<\/time>\s*<span/s');
+    }
 }


### PR DESCRIPTION
### Motivation
- Clean up the reading history timeline by removing the redundant chapter-count pill from the date header so dates stay visually simple.
- Surface chapter counts at the passage level only when a reading spans multiple contiguous chapters, which matches user expectations and reduces noise for single-chapter entries. 

### Description
- Remove the day-level chapter count pill from `resources/views/partials/reading-log-day.blade.php` so the date header no longer displays a chapters badge.
- Add a small numeric pill next to the passage label in `resources/views/components/bible/reading-log-card.blade.php` that appears only when a reading segment contains multiple chapters, and include an accessible `aria-label` (e.g. "2 chapters").
- Preserve single-chapter entries as badge-free at both the date and passage level so the UI is less repetitive.
- Update `tests/Feature/ReadingLogHistoryInfiniteScrollTest.php` to assert the new behavior: that multi-chapter passages render a passage-level badge and the date header does not show the chapter pill.

### Testing
- Ran the targeted feature test with `php artisan test --compact tests/Feature/ReadingLogHistoryInfiniteScrollTest.php` and it passed (2 tests, 12 assertions).
- Ran the formatter with `vendor/bin/pint --dirty --format agent` and it passed.
- Built frontend assets with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b6d5fd60083208f59859956196f30)