### PR TITLE
[DEL-279] Build native reading history

### DIFF
--- a/mobile/src/__tests__/log-tab-button.test.tsx
+++ b/mobile/src/__tests__/log-tab-button.test.tsx
@@ -6,14 +6,14 @@ describe('central Log tab action', () => {
   it('uses an accessible action label and opens the Log route when pressed', async () => {
     const onPress = jest.fn();
 
-    await render(<LogTabButton bottom={36} isSelected onPress={onPress} />);
+    await render(<LogTabButton bottom={20} isSelected onPress={onPress} />);
 
     const button = screen.getByRole('button', { name: 'Log a reading' });
     fireEvent.press(button);
 
     expect(onPress).toHaveBeenCalledTimes(1);
     expect(button.props.accessibilityState).toEqual({ selected: true });
-    expect(button).toHaveStyle({ position: 'absolute', bottom: 36, width: 56, height: 56 });
+    expect(button).toHaveStyle({ position: 'absolute', bottom: 20, width: 56, height: 56 });
     expect(screen.getByText('+')).toBeOnTheScreen();
     expect(screen.queryByText('Log')).not.toBeOnTheScreen();
   });

--- a/mobile/src/__tests__/reading-history.test.tsx
+++ b/mobile/src/__tests__/reading-history.test.tsx
@@ -122,6 +122,30 @@ describe('reading history', () => {
     expect(screen.getByText('You have reached the beginning of your history.')).toBeOnTheScreen();
   });
 
+  it('refreshes instead of rendering a partial overlapping group', async () => {
+    request
+      .mockResolvedValueOnce(historyResponse(1, 2, '2026-08-10', [
+        readingGroup({ log_ids: [101], end_chapter: null, passage: 'John 1' }),
+      ]))
+      .mockResolvedValueOnce(historyResponse(2, 2, '2026-08-10', [
+        readingGroup({ log_ids: [101, 102], passage: 'John 1-2' }),
+      ]))
+      .mockResolvedValueOnce(historyResponse(1, 1, '2026-08-10', [
+        readingGroup({ log_ids: [101, 102], passage: 'John 1-2' }),
+      ]));
+
+    const screen = await renderHistory();
+    await waitFor(() => expect(screen.getByText('John 1')).toBeOnTheScreen());
+    const user = userEvent.setup();
+    await user.press(screen.getByRole('button', { name: 'Load more' }));
+
+    await waitFor(() => expect(screen.getByText('John 1-2')).toBeOnTheScreen());
+
+    expect(request).toHaveBeenCalledTimes(3);
+    expect(request).toHaveBeenLastCalledWith('/api/v1/reading-logs?page=1');
+    expect(screen.queryByText('John 1')).not.toBeOnTheScreen();
+  });
+
   it('replaces appended pages from page one when refreshed', async () => {
     request
       .mockResolvedValueOnce(historyResponse(1, 2, '2026-08-10'))
@@ -278,7 +302,7 @@ describe('reading history', () => {
 });
 
 describe('mergeReadingHistoryPages', () => {
-  it('keeps the first API order while removing duplicated log IDs', () => {
+  it('keeps the first complete server group when pages overlap', () => {
     const page = (days: ReadingHistoryPage['days']): ReadingHistoryPage => ({ days, currentPage: 1, lastPage: 2 });
     const group = (logIds: number[], passage: string) => ({
       logIds,
@@ -296,6 +320,6 @@ describe('mergeReadingHistoryPages', () => {
       page([{ dateRead: '2026-08-10', groups: [group([1, 2], 'John 1-2')] }]),
     ]);
 
-    expect(result).toEqual([{ dateRead: '2026-08-10', groups: [group([1], 'John 1'), group([2], 'John 1-2')] }]);
+    expect(result).toEqual([{ dateRead: '2026-08-10', groups: [group([1], 'John 1')] }]);
   });
 });

--- a/mobile/src/__tests__/reading-history.test.tsx
+++ b/mobile/src/__tests__/reading-history.test.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, cleanup, fireEvent, render, userEvent, waitFor } from '@testing-library/react-native';
 import { router } from 'expo-router';
 import type { PropsWithChildren } from 'react';
+import { AppState } from 'react-native';
 
 import HistoryScreen from '@/app/(tabs)/history';
 import { mergeReadingHistoryPages, type ReadingHistoryPage } from '@/api/reading-history';
@@ -21,6 +22,13 @@ jest.mock('react-native/Libraries/Components/RefreshControl/RefreshControl', () 
 });
 
 const request = jest.fn();
+let mockAppStateListener: ((state: 'active' | 'background') => void) | undefined;
+
+jest.spyOn(AppState, 'addEventListener').mockImplementation((_event, listener) => {
+  mockAppStateListener = listener as (state: 'active' | 'background') => void;
+
+  return { remove: jest.fn() };
+});
 
 async function renderHistory() {
   const queryClient = new QueryClient({
@@ -57,6 +65,7 @@ function readingGroup(overrides: Partial<Record<string, unknown>> = {}) {
 
 beforeEach(() => {
   request.mockReset();
+  mockAppStateListener = undefined;
   jest.mocked(router.push).mockClear();
   jest.mocked(useAuthenticatedApi).mockReturnValue(request);
 });
@@ -99,6 +108,7 @@ describe('reading history', () => {
     const screen = await renderHistory();
     await waitFor(() => expect(screen.getByRole('button', { name: 'Load more' })).toBeOnTheScreen());
     const loadMoreButton = screen.getByRole('button', { name: 'Load more' });
+    expect(loadMoreButton).toHaveProp('accessibilityHint', 'Loads older readings from your history.');
     const user = userEvent.setup();
 
     await user.press(loadMoreButton);
@@ -137,13 +147,93 @@ describe('reading history', () => {
     expect(request).toHaveBeenLastCalledWith('/api/v1/reading-logs?page=1');
   });
 
+  it('discards a pending load-more response after refresh', async () => {
+    let resolveNextPage: (value: unknown) => void = () => undefined;
+    let resolveRefresh: (value: unknown) => void = () => undefined;
+    const nextPage = new Promise((resolve) => {
+      resolveNextPage = resolve;
+    });
+    const refreshedPage = new Promise((resolve) => {
+      resolveRefresh = resolve;
+    });
+
+    request
+      .mockResolvedValueOnce(historyResponse(1, 2, '2026-08-10'))
+      .mockReturnValueOnce(nextPage)
+      .mockReturnValueOnce(refreshedPage);
+
+    const screen = await renderHistory();
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Load more' })).toBeOnTheScreen());
+    const user = userEvent.setup();
+    await user.press(screen.getByRole('button', { name: 'Load more' }));
+
+    const refresh = screen.getByTestId('history-refresh-control').props.onRefresh as () => Promise<void>;
+    let refreshResult: Promise<void> = Promise.resolve();
+    await act(async () => {
+      refreshResult = refresh();
+    });
+    await waitFor(() => expect(request).toHaveBeenCalledTimes(3));
+
+    await act(async () => {
+      resolveRefresh(historyResponse(1, 1, '2026-08-11', [
+        readingGroup({ log_ids: [105], passage: 'John 5', date_read: '2026-08-11' }),
+      ]));
+      await refreshResult;
+    });
+    await waitFor(() => expect(screen.getByText('John 5')).toBeOnTheScreen());
+
+    await act(async () => {
+      resolveNextPage(historyResponse(2, 2, '2026-08-09', [
+        readingGroup({ log_ids: [104], passage: 'John 4', date_read: '2026-08-09' }),
+      ]));
+    });
+
+    await waitFor(() => expect(screen.queryByText('John 4')).not.toBeOnTheScreen());
+  });
+
+  it('preserves appended pages and announces a failed refresh', async () => {
+    request
+      .mockResolvedValueOnce(historyResponse(1, 2, '2026-08-10'))
+      .mockResolvedValueOnce(historyResponse(2, 2, '2026-08-09', [
+        readingGroup({ log_ids: [104], passage: 'John 4', date_read: '2026-08-09' }),
+      ]))
+      .mockRejectedValueOnce(new Error('Delight could not connect.'));
+
+    const screen = await renderHistory();
+    await waitFor(() => expect(screen.getByText('John 1-2')).toBeOnTheScreen());
+    const user = userEvent.setup();
+    await user.press(screen.getByRole('button', { name: 'Load more' }));
+    await waitFor(() => expect(screen.getByText('John 4')).toBeOnTheScreen());
+
+    await act(async () => {
+      await screen.getByTestId('history-refresh-control').props.onRefresh();
+    });
+
+    await waitFor(() => expect(screen.getByText(/History could not be refreshed/)).toBeOnTheScreen());
+    expect(screen.getByText('John 4')).toBeOnTheScreen();
+  });
+
+  it('refreshes when the app returns to the foreground', async () => {
+    request.mockResolvedValue(historyResponse(1, 1, '2026-08-10'));
+    const screen = await renderHistory();
+    await waitFor(() => expect(screen.getByText('John 1-2')).toBeOnTheScreen());
+
+    await act(async () => {
+      mockAppStateListener?.('active');
+    });
+
+    await waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+  });
+
   it('offers the Log tab when history is empty', async () => {
     request.mockResolvedValueOnce({ data: [], meta: { current_page: 1, last_page: 1 } });
 
     const screen = await renderHistory();
     await waitFor(() => expect(screen.getByText('Your history is waiting')).toBeOnTheScreen());
 
-    fireEvent.press(screen.getByRole('button', { name: 'Log a reading' }));
+    const logButton = screen.getByRole('button', { name: 'Log a reading' });
+    expect(logButton).toHaveProp('accessibilityHint', 'Opens the Log tab to record a reading.');
+    fireEvent.press(logButton);
 
     expect(router.push).toHaveBeenCalledWith('/(tabs)/log');
   });
@@ -180,6 +270,10 @@ describe('reading history', () => {
 
     expect(screen.getByText('Delight could not connect.')).toBeOnTheScreen();
     expect(screen.getByRole('button', { name: 'Try again' })).toBeOnTheScreen();
+    expect(screen.getByRole('button', { name: 'Try again' })).toHaveProp(
+      'accessibilityHint',
+      'Requests your reading history again.',
+    );
   });
 });
 
@@ -199,9 +293,9 @@ describe('mergeReadingHistoryPages', () => {
 
     const result = mergeReadingHistoryPages([
       page([{ dateRead: '2026-08-10', groups: [group([1], 'John 1')] }]),
-      page([{ dateRead: '2026-08-10', groups: [group([1], 'John 1'), group([2], 'John 2')] }]),
+      page([{ dateRead: '2026-08-10', groups: [group([1, 2], 'John 1-2')] }]),
     ]);
 
-    expect(result).toEqual([{ dateRead: '2026-08-10', groups: [group([1], 'John 1'), group([2], 'John 2')] }]);
+    expect(result).toEqual([{ dateRead: '2026-08-10', groups: [group([1], 'John 1'), group([2], 'John 1-2')] }]);
   });
 });

--- a/mobile/src/__tests__/reading-history.test.tsx
+++ b/mobile/src/__tests__/reading-history.test.tsx
@@ -1,0 +1,207 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, cleanup, fireEvent, render, userEvent, waitFor } from '@testing-library/react-native';
+import { router } from 'expo-router';
+import type { PropsWithChildren } from 'react';
+
+import HistoryScreen from '@/app/(tabs)/history';
+import { mergeReadingHistoryPages, type ReadingHistoryPage } from '@/api/reading-history';
+import { useAuthenticatedApi } from '@/auth/auth-context';
+
+jest.mock('@/auth/auth-context', () => ({ useAuthenticatedApi: jest.fn() }));
+
+jest.mock('expo-router', () => ({ router: { push: jest.fn() } }));
+
+jest.mock('react-native/Libraries/Components/RefreshControl/RefreshControl', () => {
+  const { View } = jest.requireActual('react-native');
+
+  return {
+    __esModule: true,
+    default: (props: object) => <View {...props} />,
+  };
+});
+
+const request = jest.fn();
+
+async function renderHistory() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { gcTime: 0, retry: false }, mutations: { retry: false } },
+  });
+
+  function Wrapper({ children }: PropsWithChildren) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  }
+
+  return await render(<HistoryScreen />, { wrapper: Wrapper });
+}
+
+function historyResponse(page: number, lastPage: number, date: string, groups = [readingGroup()]): unknown {
+  return {
+    data: [{ date_read: date, groups }],
+    meta: { current_page: page, last_page: lastPage },
+  };
+}
+
+function readingGroup(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    log_ids: [101, 102],
+    book: { id: 43, name: 'John' },
+    start_chapter: 1,
+    end_chapter: 2,
+    passage: 'John 1-2',
+    notes_text: 'A hopeful beginning.',
+    date_read: '2026-08-10',
+    logged_at: '2026-08-10T14:30:00.000Z',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  request.mockReset();
+  jest.mocked(router.push).mockClear();
+  jest.mocked(useAuthenticatedApi).mockReturnValue(request);
+});
+
+afterEach(cleanup);
+
+describe('reading history', () => {
+  it('renders API-ordered day groups and only renders notes when present', async () => {
+    request.mockResolvedValueOnce(historyResponse(1, 1, '2026-08-10', [
+      readingGroup(),
+      readingGroup({ log_ids: [103], start_chapter: 4, end_chapter: null, passage: 'John 4', notes_text: null }),
+    ]));
+
+    const screen = await renderHistory();
+
+    await waitFor(() => expect(screen.getByText('John 1-2')).toBeOnTheScreen());
+
+    expect(screen.getByText(/2 chapters/)).toBeOnTheScreen();
+    expect(screen.getByText('A hopeful beginning.')).toBeOnTheScreen();
+    expect(screen.getByText('John 4')).toBeOnTheScreen();
+    expect(screen.queryAllByText('A hopeful beginning.')).toHaveLength(1);
+    expect(screen.getByText('You have reached the beginning of your history.')).toBeOnTheScreen();
+  });
+
+  it('appends a next page once and suppresses duplicate date groups and readings', async () => {
+    let resolveNextPage: (value: unknown) => void = () => undefined;
+    const nextPage = new Promise((resolve) => {
+      resolveNextPage = resolve;
+    });
+
+    request
+      .mockResolvedValueOnce(historyResponse(1, 2, '2026-08-10'))
+      .mockReturnValueOnce(nextPage);
+
+    const pageTwo = historyResponse(2, 2, '2026-08-10', [
+        readingGroup(),
+        readingGroup({ log_ids: [104], start_chapter: 4, end_chapter: null, passage: 'John 4' }),
+      ]);
+
+    const screen = await renderHistory();
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Load more' })).toBeOnTheScreen());
+    const loadMoreButton = screen.getByRole('button', { name: 'Load more' });
+    const user = userEvent.setup();
+
+    await user.press(loadMoreButton);
+    await user.press(loadMoreButton);
+    resolveNextPage(pageTwo);
+
+    await waitFor(() => expect(screen.getByText(/John 4/)).toBeOnTheScreen());
+
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(screen.queryAllByText('John 1-2')).toHaveLength(1);
+    expect(screen.getByText('You have reached the beginning of your history.')).toBeOnTheScreen();
+  });
+
+  it('replaces appended pages from page one when refreshed', async () => {
+    request
+      .mockResolvedValueOnce(historyResponse(1, 2, '2026-08-10'))
+      .mockResolvedValueOnce(historyResponse(2, 2, '2026-08-09', [
+        readingGroup({ log_ids: [104], passage: 'John 4', date_read: '2026-08-09' }),
+      ]))
+      .mockResolvedValueOnce(historyResponse(1, 1, '2026-08-11', [
+        readingGroup({ log_ids: [105], passage: 'John 5', date_read: '2026-08-11' }),
+      ]));
+
+    const screen = await renderHistory();
+    await waitFor(() => expect(screen.getByText('John 1-2')).toBeOnTheScreen());
+    const user = userEvent.setup();
+    await user.press(screen.getByRole('button', { name: 'Load more' }));
+    await waitFor(() => expect(screen.getByText(/John 4/)).toBeOnTheScreen());
+
+    await act(async () => {
+      await screen.getByTestId('history-refresh-control').props.onRefresh();
+    });
+
+    await waitFor(() => expect(screen.getByText(/John 5/)).toBeOnTheScreen());
+    expect(screen.queryByText(/John 4/)).not.toBeOnTheScreen();
+    expect(request).toHaveBeenLastCalledWith('/api/v1/reading-logs?page=1');
+  });
+
+  it('offers the Log tab when history is empty', async () => {
+    request.mockResolvedValueOnce({ data: [], meta: { current_page: 1, last_page: 1 } });
+
+    const screen = await renderHistory();
+    await waitFor(() => expect(screen.getByText('Your history is waiting')).toBeOnTheScreen());
+
+    fireEvent.press(screen.getByRole('button', { name: 'Log a reading' }));
+
+    expect(router.push).toHaveBeenCalledWith('/(tabs)/log');
+  });
+
+  it('uses the newest page metadata when the history grows during pagination', async () => {
+    request
+      .mockResolvedValueOnce(historyResponse(1, 2, '2026-08-10'))
+      .mockResolvedValueOnce(historyResponse(2, 3, '2026-08-09', [
+        readingGroup({ log_ids: [104], passage: 'John 4', date_read: '2026-08-09' }),
+      ]))
+      .mockResolvedValueOnce(historyResponse(3, 3, '2026-08-08', [
+        readingGroup({ log_ids: [105], passage: 'John 5', date_read: '2026-08-08' }),
+      ]));
+
+    const screen = await renderHistory();
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Load more' })).toBeOnTheScreen());
+
+    const user = userEvent.setup();
+    await user.press(screen.getByRole('button', { name: 'Load more' }));
+    await waitFor(() => expect(screen.getByText('John 4')).toBeOnTheScreen());
+
+    await user.press(screen.getByRole('button', { name: 'Load more' }));
+    await waitFor(() => expect(screen.getByText('John 5')).toBeOnTheScreen());
+
+    expect(request).toHaveBeenCalledTimes(3);
+    expect(screen.getByText('You have reached the beginning of your history.')).toBeOnTheScreen();
+  });
+
+  it('shows a recoverable initial error', async () => {
+    request.mockRejectedValueOnce(new Error('Delight could not connect.'));
+
+    const screen = await renderHistory();
+    await waitFor(() => expect(screen.getByText('History is unavailable')).toBeOnTheScreen());
+
+    expect(screen.getByText('Delight could not connect.')).toBeOnTheScreen();
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeOnTheScreen();
+  });
+});
+
+describe('mergeReadingHistoryPages', () => {
+  it('keeps the first API order while removing duplicated log IDs', () => {
+    const page = (days: ReadingHistoryPage['days']): ReadingHistoryPage => ({ days, currentPage: 1, lastPage: 2 });
+    const group = (logIds: number[], passage: string) => ({
+      logIds,
+      book: { id: 43, name: 'John' },
+      startChapter: 1,
+      endChapter: null,
+      passage,
+      notesText: null,
+      dateRead: '2026-08-10',
+      loggedAt: null,
+    });
+
+    const result = mergeReadingHistoryPages([
+      page([{ dateRead: '2026-08-10', groups: [group([1], 'John 1')] }]),
+      page([{ dateRead: '2026-08-10', groups: [group([1], 'John 1'), group([2], 'John 2')] }]),
+    ]);
+
+    expect(result).toEqual([{ dateRead: '2026-08-10', groups: [group([1], 'John 1'), group([2], 'John 2')] }]);
+  });
+});

--- a/mobile/src/__tests__/tab-screens.test.tsx
+++ b/mobile/src/__tests__/tab-screens.test.tsx
@@ -1,12 +1,10 @@
 import { render } from '@testing-library/react-native';
 
-import HistoryScreen from '@/app/(tabs)/history';
 import LogScreen from '@/app/(tabs)/log';
 
 describe('mobile tab screens', () => {
   it.each([
     [LogScreen, 'The focused reading form will live here.'],
-    [HistoryScreen, 'Your reading history will live here.'],
   ])('renders its scoped placeholder', async (Screen, message) => {
     const { getByText } = await render(<Screen />);
 

--- a/mobile/src/api/reading-history.ts
+++ b/mobile/src/api/reading-history.ts
@@ -81,21 +81,12 @@ export function mergeReadingHistoryPages(pages: ReadingHistoryPage[]): ReadingHi
       const day = days.get(incomingDay.dateRead) ?? { dateRead: incomingDay.dateRead, groups: [] };
 
       for (const group of incomingDay.groups) {
-        const logIds = group.logIds.filter((id) => {
-          if (seenLogIds.has(id)) {
-            return false;
-          }
-
-          seenLogIds.add(id);
-
-          return true;
-        });
-
-        if (logIds.length === 0) {
+        if (group.logIds.some((id) => seenLogIds.has(id))) {
           continue;
         }
 
-        day.groups.push({ ...group, logIds });
+        group.logIds.forEach((id) => seenLogIds.add(id));
+        day.groups.push(group);
       }
 
       if (!days.has(incomingDay.dateRead)) {
@@ -105,4 +96,34 @@ export function mergeReadingHistoryPages(pages: ReadingHistoryPage[]): ReadingHi
   }
 
   return [...days.values()];
+}
+
+export function hasPartialReadingHistoryOverlap(
+  existingPages: ReadingHistoryPage[],
+  incomingPage: ReadingHistoryPage,
+): boolean {
+  const seenLogIds = new Set<number>();
+
+  for (const page of existingPages) {
+    for (const day of page.days) {
+      for (const group of day.groups) {
+        group.logIds.forEach((id) => seenLogIds.add(id));
+      }
+    }
+  }
+
+  for (const day of incomingPage.days) {
+    for (const group of day.groups) {
+      const hasSeenLog = group.logIds.some((id) => seenLogIds.has(id));
+      const hasUnseenLog = group.logIds.some((id) => !seenLogIds.has(id));
+
+      if (hasSeenLog && hasUnseenLog) {
+        return true;
+      }
+
+      group.logIds.forEach((id) => seenLogIds.add(id));
+    }
+  }
+
+  return false;
 }

--- a/mobile/src/api/reading-history.ts
+++ b/mobile/src/api/reading-history.ts
@@ -1,0 +1,101 @@
+import type { AuthenticatedRequestOptions } from '@/auth/auth-context';
+
+export type ReadingHistoryGroup = {
+  logIds: number[];
+  book: {
+    id: number;
+    name: string;
+  };
+  startChapter: number;
+  endChapter: number | null;
+  passage: string;
+  notesText: string | null;
+  dateRead: string;
+  loggedAt: string | null;
+};
+
+export type ReadingHistoryDay = {
+  dateRead: string;
+  groups: ReadingHistoryGroup[];
+};
+
+export type ReadingHistoryPage = {
+  days: ReadingHistoryDay[];
+  currentPage: number;
+  lastPage: number;
+};
+
+type ReadingHistoryResponse = {
+  data: {
+    date_read: string;
+    groups: {
+      log_ids: number[];
+      book: { id: number; name: string };
+      start_chapter: number;
+      end_chapter: number | null;
+      passage: string;
+      notes_text: string | null;
+      date_read: string;
+      logged_at: string | null;
+    }[];
+  }[];
+  meta: {
+    current_page: number;
+    last_page: number;
+  };
+};
+
+type AuthenticatedApi = <T>(path: string, options?: AuthenticatedRequestOptions) => Promise<T>;
+
+export async function fetchReadingHistoryPage(
+  request: AuthenticatedApi,
+  page: number,
+): Promise<ReadingHistoryPage> {
+  const response = await request<ReadingHistoryResponse>(`/api/v1/reading-logs?page=${page}`);
+
+  return {
+    days: response.data.map((day) => ({
+      dateRead: day.date_read,
+      groups: day.groups.map((group) => ({
+        logIds: group.log_ids,
+        book: group.book,
+        startChapter: group.start_chapter,
+        endChapter: group.end_chapter,
+        passage: group.passage,
+        notesText: group.notes_text,
+        dateRead: group.date_read,
+        loggedAt: group.logged_at,
+      })),
+    })),
+    currentPage: response.meta.current_page,
+    lastPage: response.meta.last_page,
+  };
+}
+
+export function mergeReadingHistoryPages(pages: ReadingHistoryPage[]): ReadingHistoryDay[] {
+  const days = new Map<string, ReadingHistoryDay>();
+  const seenLogIds = new Set<number>();
+
+  for (const page of pages) {
+    for (const incomingDay of page.days) {
+      const day = days.get(incomingDay.dateRead) ?? { dateRead: incomingDay.dateRead, groups: [] };
+
+      for (const group of incomingDay.groups) {
+        const hasNewLog = group.logIds.some((id) => !seenLogIds.has(id));
+
+        if (!hasNewLog) {
+          continue;
+        }
+
+        group.logIds.forEach((id) => seenLogIds.add(id));
+        day.groups.push(group);
+      }
+
+      if (!days.has(incomingDay.dateRead)) {
+        days.set(incomingDay.dateRead, day);
+      }
+    }
+  }
+
+  return [...days.values()];
+}

--- a/mobile/src/api/reading-history.ts
+++ b/mobile/src/api/reading-history.ts
@@ -81,14 +81,21 @@ export function mergeReadingHistoryPages(pages: ReadingHistoryPage[]): ReadingHi
       const day = days.get(incomingDay.dateRead) ?? { dateRead: incomingDay.dateRead, groups: [] };
 
       for (const group of incomingDay.groups) {
-        const hasNewLog = group.logIds.some((id) => !seenLogIds.has(id));
+        const logIds = group.logIds.filter((id) => {
+          if (seenLogIds.has(id)) {
+            return false;
+          }
 
-        if (!hasNewLog) {
+          seenLogIds.add(id);
+
+          return true;
+        });
+
+        if (logIds.length === 0) {
           continue;
         }
 
-        group.logIds.forEach((id) => seenLogIds.add(id));
-        day.groups.push(group);
+        day.groups.push({ ...group, logIds });
       }
 
       if (!days.has(incomingDay.dateRead)) {

--- a/mobile/src/app/(tabs)/_layout.tsx
+++ b/mobile/src/app/(tabs)/_layout.tsx
@@ -61,7 +61,7 @@ export default function TabsLayout() {
           />
         </Tabs>
         <LogTabButton
-          bottom={insets.bottom + 36}
+          bottom={insets.bottom + 20}
           isSelected={isLogRoute}
           onPress={() => router.navigate('/(tabs)/log')}
         />

--- a/mobile/src/app/(tabs)/history/index.tsx
+++ b/mobile/src/app/(tabs)/history/index.tsx
@@ -1,5 +1,5 @@
-import { ScreenPlaceholder } from '@/components/screen-placeholder';
+import { ReadingHistory } from '@/components/reading-history';
 
 export default function HistoryScreen() {
-  return <ScreenPlaceholder message="Your reading history will live here." />;
+  return <ReadingHistory />;
 }

--- a/mobile/src/components/reading-history.tsx
+++ b/mobile/src/components/reading-history.tsx
@@ -14,6 +14,7 @@ import {
 
 import {
   fetchReadingHistoryPage,
+  hasPartialReadingHistoryOverlap,
   mergeReadingHistoryPages,
   type ReadingHistoryDay,
   type ReadingHistoryGroup,
@@ -83,6 +84,12 @@ function useReadingHistory() {
         return;
       }
 
+      if (hasPartialReadingHistoryOverlap(pages, page)) {
+        await refresh();
+
+        return;
+      }
+
       setLoadedPages((currentPages) => {
         if (currentPages.some((currentPage) => currentPage.currentPage === page.currentPage)) {
           return currentPages;
@@ -98,7 +105,7 @@ function useReadingHistory() {
       isLoadingMoreRef.current = false;
       setIsLoadingMore(false);
     }
-  }, [hasNextPage, lastLoadedPage, request]);
+  }, [hasNextPage, lastLoadedPage, pages, refresh, request]);
 
   return {
     days,

--- a/mobile/src/components/reading-history.tsx
+++ b/mobile/src/components/reading-history.tsx
@@ -1,7 +1,16 @@
 import { useQuery } from '@tanstack/react-query';
 import { router } from 'expo-router';
-import { useCallback, useMemo, useRef, useState } from 'react';
-import { ActivityIndicator, Pressable, RefreshControl, ScrollView, Text, View } from 'react-native';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  AppState,
+  type AppStateStatus,
+  Pressable,
+  RefreshControl,
+  ScrollView,
+  Text,
+  View,
+} from 'react-native';
 
 import {
   fetchReadingHistoryPage,
@@ -20,11 +29,13 @@ function useReadingHistory() {
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [loadMoreError, setLoadMoreError] = useState<Error | null>(null);
   const isLoadingMoreRef = useRef(false);
+  const refreshGenerationRef = useRef(0);
 
   const initialPage = useQuery({
     queryKey: ['reading-history', 1],
     queryFn: () => fetchReadingHistoryPage(request, 1),
   });
+  const { refetch } = initialPage;
 
   const pages = useMemo(
     () => initialPage.data ? [initialPage.data, ...loadedPages] : [],
@@ -36,10 +47,24 @@ function useReadingHistory() {
   const hasNextPage = initialPage.data !== undefined && lastLoadedPage < lastPage;
 
   const refresh = useCallback(async () => {
-    setLoadedPages([]);
+    const refreshGeneration = ++refreshGenerationRef.current;
     setLoadMoreError(null);
-    await initialPage.refetch();
-  }, [initialPage]);
+    const result = await refetch();
+
+    if (refreshGeneration === refreshGenerationRef.current && result.isSuccess) {
+      setLoadedPages([]);
+    }
+  }, [refetch]);
+
+  useEffect(() => {
+    function refreshWhenForegrounded(nextAppState: AppStateStatus) {
+      if (nextAppState === 'active') {
+        void refresh();
+      }
+    }
+
+    return AppState.addEventListener('change', refreshWhenForegrounded).remove;
+  }, [refresh]);
 
   const loadMore = useCallback(async () => {
     if (!hasNextPage || isLoadingMoreRef.current) {
@@ -47,11 +72,17 @@ function useReadingHistory() {
     }
 
     isLoadingMoreRef.current = true;
+    const refreshGeneration = refreshGenerationRef.current;
     setIsLoadingMore(true);
     setLoadMoreError(null);
 
     try {
       const page = await fetchReadingHistoryPage(request, lastLoadedPage + 1);
+
+      if (refreshGeneration !== refreshGenerationRef.current) {
+        return;
+      }
+
       setLoadedPages((currentPages) => {
         if (currentPages.some((currentPage) => currentPage.currentPage === page.currentPage)) {
           return currentPages;
@@ -60,7 +91,9 @@ function useReadingHistory() {
         return [...currentPages, page];
       });
     } catch (error) {
-      setLoadMoreError(error instanceof Error ? error : new Error('The next page could not be loaded.'));
+      if (refreshGeneration === refreshGenerationRef.current) {
+        setLoadMoreError(error instanceof Error ? error : new Error('The next page could not be loaded.'));
+      }
     } finally {
       isLoadingMoreRef.current = false;
       setIsLoadingMore(false);
@@ -74,9 +107,11 @@ function useReadingHistory() {
     initialError: initialPage.error instanceof Error ? initialPage.error : null,
     isLoadingMore,
     loadMoreError,
+    refreshError:
+      initialPage.isRefetchError && initialPage.error instanceof Error ? initialPage.error : null,
     hasNextPage,
     refresh,
-    retryInitial: initialPage.refetch,
+    retryInitial: refetch,
     loadMore,
   };
 }
@@ -99,7 +134,17 @@ function chapterCount(group: ReadingHistoryGroup): string {
   return `${count} ${count === 1 ? 'chapter' : 'chapters'}`;
 }
 
-function ActionButton({ label, onPress, tone = 'primary' }: { label: string; onPress: () => void; tone?: 'primary' | 'accent' }) {
+function ActionButton({
+  label,
+  accessibilityHint,
+  onPress,
+  tone = 'primary',
+}: Readonly<{
+  label: string;
+  accessibilityHint: string;
+  onPress: () => void;
+  tone?: 'primary' | 'accent';
+}>) {
   const { colors } = useTheme();
   const isAccent = tone === 'accent';
 
@@ -107,6 +152,7 @@ function ActionButton({ label, onPress, tone = 'primary' }: { label: string; onP
     <Pressable
       accessibilityRole="button"
       accessibilityLabel={label}
+      accessibilityHint={accessibilityHint}
       onPress={onPress}
       style={({ pressed }) => ({
         alignItems: 'center',
@@ -194,7 +240,11 @@ export function ReadingHistory() {
       <View accessibilityLiveRegion="polite" style={{ flex: 1, justifyContent: 'center', gap: 16, padding: themeTokens.spacing.screen }}>
         <Text selectable style={{ color: colors.text, fontSize: 20, fontWeight: '700' }}>History is unavailable</Text>
         <Text selectable style={{ color: colors.mutedText, fontSize: 16, lineHeight: 24 }}>{history.initialError.message}</Text>
-        <ActionButton label="Try again" onPress={() => void history.retryInitial()} />
+        <ActionButton
+          label="Try again"
+          accessibilityHint="Requests your reading history again."
+          onPress={() => void history.retryInitial()}
+        />
       </View>
     );
   }
@@ -212,13 +262,27 @@ export function ReadingHistory() {
       style={{ backgroundColor: colors.background }}
       contentContainerStyle={{ gap: 24, padding: themeTokens.spacing.screen }}
     >
+      {history.refreshError ? (
+        <Text
+          accessibilityLiveRegion="polite"
+          selectable
+          style={{ color: colors.danger, fontSize: 16, lineHeight: 24 }}
+        >
+          History could not be refreshed. {history.refreshError.message}
+        </Text>
+      ) : null}
       {history.days.length === 0 ? (
         <View accessibilityLiveRegion="polite" style={{ gap: 16, paddingTop: 48 }}>
           <Text selectable style={{ color: colors.text, fontSize: 22, fontWeight: '700' }}>Your history is waiting</Text>
           <Text selectable style={{ color: colors.mutedText, fontSize: 16, lineHeight: 24 }}>
             Log a reading to begin building your record here.
           </Text>
-          <ActionButton label="Log a reading" onPress={() => router.push('/(tabs)/log')} tone="accent" />
+          <ActionButton
+            label="Log a reading"
+            accessibilityHint="Opens the Log tab to record a reading."
+            onPress={() => router.push('/(tabs)/log')}
+            tone="accent"
+          />
         </View>
       ) : (
         <>
@@ -231,7 +295,11 @@ export function ReadingHistory() {
               {history.isLoadingMore ? (
                 <ActivityIndicator accessibilityLabel="Loading more history" color={colors.primary} />
               ) : null}
-              <ActionButton label="Load more" onPress={() => void history.loadMore()} />
+              <ActionButton
+                label="Load more"
+                accessibilityHint="Loads older readings from your history."
+                onPress={() => void history.loadMore()}
+              />
             </View>
           ) : (
             <Text accessibilityLiveRegion="polite" selectable style={{ color: colors.mutedText, fontSize: 15, textAlign: 'center' }}>

--- a/mobile/src/components/reading-history.tsx
+++ b/mobile/src/components/reading-history.tsx
@@ -1,0 +1,245 @@
+import { useQuery } from '@tanstack/react-query';
+import { router } from 'expo-router';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { ActivityIndicator, Pressable, RefreshControl, ScrollView, Text, View } from 'react-native';
+
+import {
+  fetchReadingHistoryPage,
+  mergeReadingHistoryPages,
+  type ReadingHistoryDay,
+  type ReadingHistoryGroup,
+  type ReadingHistoryPage,
+} from '@/api/reading-history';
+import { useAuthenticatedApi } from '@/auth/auth-context';
+import { themeTokens } from '@/theme/tokens';
+import { useTheme } from '@/theme/use-theme';
+
+function useReadingHistory() {
+  const request = useAuthenticatedApi();
+  const [loadedPages, setLoadedPages] = useState<ReadingHistoryPage[]>([]);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [loadMoreError, setLoadMoreError] = useState<Error | null>(null);
+  const isLoadingMoreRef = useRef(false);
+
+  const initialPage = useQuery({
+    queryKey: ['reading-history', 1],
+    queryFn: () => fetchReadingHistoryPage(request, 1),
+  });
+
+  const pages = useMemo(
+    () => initialPage.data ? [initialPage.data, ...loadedPages] : [],
+    [initialPage.data, loadedPages],
+  );
+  const days = useMemo(() => mergeReadingHistoryPages(pages), [pages]);
+  const lastLoadedPage = loadedPages.at(-1)?.currentPage ?? initialPage.data?.currentPage ?? 0;
+  const lastPage = loadedPages.at(-1)?.lastPage ?? initialPage.data?.lastPage ?? 0;
+  const hasNextPage = initialPage.data !== undefined && lastLoadedPage < lastPage;
+
+  const refresh = useCallback(async () => {
+    setLoadedPages([]);
+    setLoadMoreError(null);
+    await initialPage.refetch();
+  }, [initialPage]);
+
+  const loadMore = useCallback(async () => {
+    if (!hasNextPage || isLoadingMoreRef.current) {
+      return;
+    }
+
+    isLoadingMoreRef.current = true;
+    setIsLoadingMore(true);
+    setLoadMoreError(null);
+
+    try {
+      const page = await fetchReadingHistoryPage(request, lastLoadedPage + 1);
+      setLoadedPages((currentPages) => {
+        if (currentPages.some((currentPage) => currentPage.currentPage === page.currentPage)) {
+          return currentPages;
+        }
+
+        return [...currentPages, page];
+      });
+    } catch (error) {
+      setLoadMoreError(error instanceof Error ? error : new Error('The next page could not be loaded.'));
+    } finally {
+      isLoadingMoreRef.current = false;
+      setIsLoadingMore(false);
+    }
+  }, [hasNextPage, lastLoadedPage, request]);
+
+  return {
+    days,
+    isInitialLoading: initialPage.isLoading,
+    isRefreshing: initialPage.isRefetching,
+    initialError: initialPage.error instanceof Error ? initialPage.error : null,
+    isLoadingMore,
+    loadMoreError,
+    hasNextPage,
+    refresh,
+    retryInitial: initialPage.refetch,
+    loadMore,
+  };
+}
+
+function formatDate(date: string): string {
+  return new Intl.DateTimeFormat(undefined, { dateStyle: 'full' }).format(new Date(`${date}T12:00:00`));
+}
+
+function formatTime(timestamp: string | null): string | null {
+  if (!timestamp) {
+    return null;
+  }
+
+  return new Intl.DateTimeFormat(undefined, { hour: 'numeric', minute: '2-digit' }).format(new Date(timestamp));
+}
+
+function chapterCount(group: ReadingHistoryGroup): string {
+  const count = (group.endChapter ?? group.startChapter) - group.startChapter + 1;
+
+  return `${count} ${count === 1 ? 'chapter' : 'chapters'}`;
+}
+
+function ActionButton({ label, onPress, tone = 'primary' }: { label: string; onPress: () => void; tone?: 'primary' | 'accent' }) {
+  const { colors } = useTheme();
+  const isAccent = tone === 'accent';
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      onPress={onPress}
+      style={({ pressed }) => ({
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: themeTokens.minimumTouchTarget,
+        paddingHorizontal: 16,
+        borderRadius: themeTokens.radius.control,
+        borderCurve: 'continuous',
+        backgroundColor: isAccent ? colors.accentAction : colors.primary,
+        opacity: pressed ? 0.8 : 1,
+      })}
+    >
+      <Text
+        selectable
+        style={{ color: isAccent ? colors.accentActionContrast : colors.primaryContrast, fontSize: 16, fontWeight: '700' }}
+      >
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+function HistoryDay({ day }: { day: ReadingHistoryDay }) {
+  const { colors } = useTheme();
+
+  return (
+    <View accessibilityRole="header" style={{ gap: 12 }}>
+      <Text selectable style={{ color: colors.text, fontSize: 19, fontWeight: '700' }}>
+        {formatDate(day.dateRead)}
+      </Text>
+      {day.groups.map((group) => {
+        const time = formatTime(group.loggedAt);
+
+        return (
+          <View
+            key={group.logIds.join('-')}
+            style={{
+              gap: 8,
+              padding: themeTokens.spacing.section,
+              borderRadius: themeTokens.radius.card,
+              borderCurve: 'continuous',
+              borderWidth: 1,
+              borderColor: colors.border,
+              backgroundColor: colors.surface,
+            }}
+          >
+            <Text selectable style={{ color: colors.text, fontSize: 18, fontWeight: '700' }}>
+              {group.passage}
+            </Text>
+            <Text selectable style={{ color: colors.mutedText, fontSize: 15 }}>
+              {group.book.name} · {chapterCount(group)}
+            </Text>
+            {group.notesText ? (
+              <Text selectable style={{ color: colors.text, fontSize: 16, lineHeight: 24 }}>
+                {group.notesText}
+              </Text>
+            ) : null}
+            {time ? (
+              <Text selectable style={{ color: colors.mutedText, fontSize: 14 }}>
+                Logged at {time}
+              </Text>
+            ) : null}
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+export function ReadingHistory() {
+  const { colors } = useTheme();
+  const history = useReadingHistory();
+
+  if (history.isInitialLoading) {
+    return (
+      <View accessibilityLiveRegion="polite" style={{ flex: 1, alignItems: 'center', justifyContent: 'center', gap: 12 }}>
+        <ActivityIndicator accessibilityLabel="Loading reading history" color={colors.primary} />
+        <Text selectable style={{ color: colors.mutedText, fontSize: 16 }}>Loading your reading history…</Text>
+      </View>
+    );
+  }
+
+  if (history.initialError && history.days.length === 0) {
+    return (
+      <View accessibilityLiveRegion="polite" style={{ flex: 1, justifyContent: 'center', gap: 16, padding: themeTokens.spacing.screen }}>
+        <Text selectable style={{ color: colors.text, fontSize: 20, fontWeight: '700' }}>History is unavailable</Text>
+        <Text selectable style={{ color: colors.mutedText, fontSize: 16, lineHeight: 24 }}>{history.initialError.message}</Text>
+        <ActionButton label="Try again" onPress={() => void history.retryInitial()} />
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView
+      contentInsetAdjustmentBehavior="automatic"
+      refreshControl={(
+        <RefreshControl
+          refreshing={history.isRefreshing}
+          onRefresh={history.refresh}
+          testID="history-refresh-control"
+        />
+      )}
+      style={{ backgroundColor: colors.background }}
+      contentContainerStyle={{ gap: 24, padding: themeTokens.spacing.screen }}
+    >
+      {history.days.length === 0 ? (
+        <View accessibilityLiveRegion="polite" style={{ gap: 16, paddingTop: 48 }}>
+          <Text selectable style={{ color: colors.text, fontSize: 22, fontWeight: '700' }}>Your history is waiting</Text>
+          <Text selectable style={{ color: colors.mutedText, fontSize: 16, lineHeight: 24 }}>
+            Log a reading to begin building your record here.
+          </Text>
+          <ActionButton label="Log a reading" onPress={() => router.push('/(tabs)/log')} tone="accent" />
+        </View>
+      ) : (
+        <>
+          {history.days.map((day) => <HistoryDay key={day.dateRead} day={day} />)}
+          {history.hasNextPage ? (
+            <View accessibilityLiveRegion="polite" style={{ gap: 12 }}>
+              {history.loadMoreError ? (
+                <Text selectable style={{ color: colors.danger, fontSize: 16 }}>{history.loadMoreError.message}</Text>
+              ) : null}
+              {history.isLoadingMore ? (
+                <ActivityIndicator accessibilityLabel="Loading more history" color={colors.primary} />
+              ) : null}
+              <ActionButton label="Load more" onPress={() => void history.loadMore()} />
+            </View>
+          ) : (
+            <Text accessibilityLiveRegion="polite" selectable style={{ color: colors.mutedText, fontSize: 15, textAlign: 'center' }}>
+              You have reached the beginning of your history.
+            </Text>
+          )}
+        </>
+      )}
+    </ScrollView>
+  );
+}


### PR DESCRIPTION
## Summary

Implements the native, read-only reading History tab for DEL-279. The app now retrieves the paginated Laravel reading-log history, renders its grouped days and contiguous passages, and keeps navigation focused on the existing Log action.

## User impact and implementation

Readers can review their recorded passages by date, see chapter counts, optional notes, and logged time, load older eight-day pages, and refresh the list. Empty, loading, recoverable-error, paginated-loading, and exhausted states are all represented accessibly. The empty-state Log CTA uses the shared accent action, while ordinary History navigation remains primary.

History pages are deduplicated by date and log ID, rapid Load more taps are guarded, refresh replaces stale appended pages from page one, and pagination uses the newest server page metadata so newly added reading days do not hide later pages.

The implementation matches the current Home convention: API mapping lives under `mobile/src/api`, while screen-specific state and rendering live under `mobile/src/components`.

## Validation

- `npm ci`
- `npm run lint`
- `npm run typecheck`
- `npm test` (58 passing tests)
- `npm run config:validate`
- `git diff --check`

Expo Go validation remains a manual follow-up; no device run was claimed in this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reading history screen displaying entries by date, chapter counts, notes, and reading times.
  * Added pull-to-refresh, pagination, duplicate handling, loading and error states, empty states, and navigation to reading logs.
* **Bug Fixes**
  * Moved the floating Log button closer to the bottom safe-area inset for improved positioning.
* **Tests**
  * Added comprehensive coverage for reading history rendering, pagination, refresh behavior, error recovery, empty states, and duplicate suppression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->