### PR TITLE
[codex] Handle PostgreSQL duplicate reading logs

### DIFF
--- a/app/Http/Controllers/Api/V1/ReadingLogController.php
+++ b/app/Http/Controllers/Api/V1/ReadingLogController.php
@@ -36,7 +36,7 @@ class ReadingLogController extends Controller
         try {
             $result = $this->readingLogService->logReadingWithResult($request->user(), $data);
         } catch (QueryException $exception) {
-            if ($exception->getCode() !== '23000') {
+            if (! in_array((string) $exception->getCode(), ['23000', '23505'], true)) {
                 throw $exception;
             }
 

--- a/app/Http/Controllers/ReadingLogController.php
+++ b/app/Http/Controllers/ReadingLogController.php
@@ -187,7 +187,7 @@ class ReadingLogController extends Controller
             ));
         } catch (QueryException $e) {
             // Handle unique constraint violation (duplicate reading log)
-            if ($e->getCode() === '23000') {
+            if (in_array((string) $e->getCode(), ['23000', '23505'], true)) {
                 // Get books data for form re-display
                 $includeDeuterocanonical = $request->user()->includesDeuterocanonicalBooks();
                 $books = $this->bibleReferenceService->listBibleBooks(null, 'en', $includeDeuterocanonical);

--- a/tests/Feature/Api/V1/MobileReadingLogApiTest.php
+++ b/tests/Feature/Api/V1/MobileReadingLogApiTest.php
@@ -5,7 +5,10 @@ use App\Models\BookProgress;
 use App\Models\ChurnRecoveryCampaign;
 use App\Models\ReadingLog;
 use App\Models\User;
+use App\Services\ReadingLogResult;
+use App\Services\ReadingLogService;
 use Carbon\Carbon;
+use Illuminate\Database\QueryException;
 
 const MOBILE_READING_LOGS_ENDPOINT = '/api/v1/reading-logs';
 
@@ -166,6 +169,34 @@ it('rolls back earlier logs and progress when a range fails partway through', fu
         'user_id' => $user->id,
         'book_id' => 43,
     ]);
+});
+
+it('returns a validation error for a PostgreSQL duplicate chapter constraint', function () {
+    $user = User::factory()->create();
+
+    app()->instance(ReadingLogService::class, new class extends ReadingLogService
+    {
+        public function __construct() {}
+
+        public function logReadingWithResult(User $user, array $data, bool $evaluateAchievements = true): ReadingLogResult
+        {
+            throw new QueryException(
+                'pgsql',
+                'insert into "reading_logs" ...',
+                [],
+                new PDOException('duplicate key value violates unique constraint', 23505)
+            );
+        }
+    });
+
+    $this->withToken(mobileReadingToken($user))->postJson(MOBILE_READING_LOGS_ENDPOINT, [
+        'book_id' => 43,
+        'start_chapter' => 3,
+        'date_read' => today()->toDateString(),
+    ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors('start_chapter')
+        ->assertJsonPath('errors.start_chapter.0', 'One or more of these chapters have already been logged for this date.');
 });
 
 it('returns only the users history newest first grouped by date session and contiguous chapters', function () {

--- a/tests/Feature/ReadingLogChapterInputTest.php
+++ b/tests/Feature/ReadingLogChapterInputTest.php
@@ -3,8 +3,12 @@
 namespace Tests\Feature;
 
 use App\Models\User;
+use App\Services\ReadingLogResult;
+use App\Services\ReadingLogService;
+use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
+use PDOException;
 use Tests\TestCase;
 
 class ReadingLogChapterInputTest extends TestCase
@@ -119,6 +123,34 @@ class ReadingLogChapterInputTest extends TestCase
         $this->assertMatchesRegularExpression('/<input[^>]+id="yesterday"[^>]+checked/s', $response->getContent());
         $this->assertDoesNotMatchRegularExpression('/<input[^>]+id="today"[^>]+checked/s', $response->getContent());
         $this->assertDatabaseCount('reading_logs', 1);
+    }
+
+    public function test_postgresql_duplicate_chapter_displays_the_correct_error(): void
+    {
+        $user = User::factory()->create();
+
+        $this->app->instance(ReadingLogService::class, new class extends ReadingLogService
+        {
+            public function __construct() {}
+
+            public function logReadingWithResult(User $user, array $data, bool $evaluateAchievements = true): ReadingLogResult
+            {
+                throw new QueryException(
+                    'pgsql',
+                    'insert into "reading_logs" ...',
+                    [],
+                    new PDOException('duplicate key value violates unique constraint', 23505)
+                );
+            }
+        });
+
+        $response = $this->actingAs($user)->post('/logs', [
+            'book_id' => 1,
+            'start_chapter' => '1',
+            'date_read' => today()->toDateString(),
+        ]);
+
+        $response->assertSee('You have already logged one or more of these chapters for today.');
     }
 
     public function test_yesterday_selection_is_preserved_when_validation_fails(): void


### PR DESCRIPTION
## Problem

Submitting a duplicate reading chapter on PostgreSQL returned a 500 response. Mobile received the raw database exception, and the web log form failed rather than showing its existing duplicate-reading message.

## Cause

Both web and API controllers recognized the SQLite/MySQL unique-constraint SQLSTATE (23000) only. PostgreSQL reports its unique-constraint violations as SQLSTATE 23505.

## Fix

Treat 23505 as the same duplicate-reading validation case in both controllers, while preserving the rethrow path for unrelated database failures. The API returns its established 422 field error; the web form re-renders with its established start-chapter message.

## Verification

- php artisan test --compact tests/Feature/Api/V1/MobileReadingLogApiTest.php (17 passed, 80 assertions)
- Focused PostgreSQL duplicate constraint regression tests for the API and web controller
- vendor/bin/pint --dirty --format agent
- git diff --check

Note: the broader legacy ReadingLogChapterInputTest file has six pre-existing assertions that expect a full view, but the current controller returns an HTMX fragment in this environment. The new focused web regression passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Duplicate reading entries now produce the correct validation message across both MySQL and PostgreSQL databases.
  - Prevented duplicate-chapter submissions from triggering an unexpected server error.
  - Web and mobile/API reading-log experiences now handle duplicate entries consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->