### PR TITLE
[DEL-283] Add native icons to bottom navigation

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -8,6 +8,7 @@
       "name": "delight-mobile",
       "version": "0.1.0",
       "dependencies": {
+        "@expo/vector-icons": "^15.0.2",
         "@hookform/resolvers": "^5.7.1",
         "@tanstack/react-query": "^5.101.4",
         "expo": "~57.0.11",
@@ -2095,6 +2096,17 @@
         "react-native-worklets": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@expo/vector-icons": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@expo/vector-icons/-/vector-icons-15.1.1.tgz",
+      "integrity": "sha512-Iu2VkcoI5vygbtYngm7jb4ifxElNVXQYdDrYkT7UCEIiKLeWnQY0wf2ZhHZ+Wro6Sc5TaumpKUOqDRpLi5rkvw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo-font": ">=14.0.4",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/@expo/xcpretty": {
@@ -4695,24 +4707,6 @@
       },
       "engines": {
         "node": ">=18.18"
-      }
-    },
-    "node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/anser": {
@@ -7989,24 +7983,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/fb-dotslash": {
       "version": "0.5.8",
       "resolved": "https://registry.npmjs.org/fb-dotslash/-/fb-dotslash-0.5.8.tgz",
@@ -8297,7 +8273,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -10878,14 +10853,6 @@
       "devOptional": true,
       "license": "MIT"
     },
-    "node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -13418,17 +13385,6 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -3,6 +3,7 @@
   "main": "expo-router/entry",
   "version": "0.1.0",
   "dependencies": {
+    "@expo/vector-icons": "^15.0.2",
     "@hookform/resolvers": "^5.7.1",
     "@tanstack/react-query": "^5.101.4",
     "expo": "~57.0.11",

--- a/mobile/src/__tests__/bottom-navigation-icon.test.tsx
+++ b/mobile/src/__tests__/bottom-navigation-icon.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react-native';
+
+import { BottomNavigationIcon, bottomNavigationIcons } from '@/components/bottom-navigation-icon';
+
+describe('bottom navigation icons', () => {
+  it('maps the native icons to the web navigation meanings', async () => {
+    expect(bottomNavigationIcons).toEqual({
+      home: 'chart-line',
+      log: 'plus',
+      history: 'history',
+    });
+
+    await render(
+      <BottomNavigationIcon
+        color="#3366cc"
+        name={bottomNavigationIcons.home}
+        size={24}
+        testID="home-tab-icon"
+      />,
+    );
+
+    expect(screen.getByTestId('home-tab-icon')).toBeOnTheScreen();
+  });
+});

--- a/mobile/src/__tests__/log-tab-button.test.tsx
+++ b/mobile/src/__tests__/log-tab-button.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react-native';
 
+import { bottomNavigationIcons } from '@/components/bottom-navigation-icon';
 import { LogTabButton } from '@/components/log-tab-button';
 
 describe('central Log tab action', () => {
@@ -14,7 +15,8 @@ describe('central Log tab action', () => {
     expect(onPress).toHaveBeenCalledTimes(1);
     expect(button.props.accessibilityState).toEqual({ selected: true });
     expect(button).toHaveStyle({ position: 'absolute', bottom: 20, width: 56, height: 56 });
-    expect(screen.getByText('+')).toBeOnTheScreen();
+    expect(bottomNavigationIcons.log).toBe('plus');
+    expect(screen.getByTestId('log-tab-icon')).toBeOnTheScreen();
     expect(screen.queryByText('Log')).not.toBeOnTheScreen();
   });
 });

--- a/mobile/src/app/(tabs)/_layout.tsx
+++ b/mobile/src/app/(tabs)/_layout.tsx
@@ -1,9 +1,11 @@
 import { Tabs, usePathname, useRouter } from 'expo-router';
 import type { BottomTabBarButtonProps } from 'expo-router/build/react-navigation/bottom-tabs';
+import type { ColorValue } from 'react-native';
 import { View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { AuthGate } from '@/auth/auth-gate';
+import { BottomNavigationIcon, bottomNavigationIcons } from '@/components/bottom-navigation-icon';
 import { LogTabButton } from '@/components/log-tab-button';
 import { StandardTabButton } from '@/components/standard-tab-button';
 import { useTheme } from '@/theme/use-theme';
@@ -14,6 +16,14 @@ function renderLogTabSpacer({ style }: BottomTabBarButtonProps) {
 
 function renderStandardTabButton(props: BottomTabBarButtonProps) {
   return <StandardTabButton {...props} />;
+}
+
+function renderHomeTabIcon({ color, size }: { color: ColorValue; size: number }) {
+  return <BottomNavigationIcon color={color} name={bottomNavigationIcons.home} size={size} />;
+}
+
+function renderHistoryTabIcon({ color, size }: { color: ColorValue; size: number }) {
+  return <BottomNavigationIcon color={color} name={bottomNavigationIcons.history} size={size} />;
 }
 
 export default function TabsLayout() {
@@ -41,7 +51,12 @@ export default function TabsLayout() {
         >
           <Tabs.Screen
             name="home"
-            options={{ title: 'Home', tabBarAccessibilityLabel: 'Home tab', tabBarButton: renderStandardTabButton }}
+            options={{
+              title: 'Home',
+              tabBarAccessibilityLabel: 'Home tab',
+              tabBarButton: renderStandardTabButton,
+              tabBarIcon: renderHomeTabIcon,
+            }}
           />
           <Tabs.Screen
             name="log"
@@ -57,6 +72,7 @@ export default function TabsLayout() {
               title: 'History',
               tabBarAccessibilityLabel: 'Reading history tab',
               tabBarButton: renderStandardTabButton,
+              tabBarIcon: renderHistoryTabIcon,
             }}
           />
         </Tabs>

--- a/mobile/src/components/bottom-navigation-icon.tsx
+++ b/mobile/src/components/bottom-navigation-icon.tsx
@@ -1,0 +1,27 @@
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import type { ColorValue } from 'react-native';
+
+export const bottomNavigationIcons = {
+  home: 'chart-line',
+  log: 'plus',
+  history: 'history',
+} as const;
+
+type BottomNavigationIconProps = {
+  color: ColorValue;
+  name: (typeof bottomNavigationIcons)[keyof typeof bottomNavigationIcons];
+  size: number;
+  testID?: string;
+};
+
+export function BottomNavigationIcon({ color, name, size, testID }: Readonly<BottomNavigationIconProps>) {
+  return (
+    <MaterialCommunityIcons
+      accessible={false}
+      color={color}
+      name={name}
+      size={size}
+      testID={testID}
+    />
+  );
+}

--- a/mobile/src/components/log-tab-button.tsx
+++ b/mobile/src/components/log-tab-button.tsx
@@ -1,6 +1,7 @@
 import type { GestureResponderEvent } from 'react-native';
-import { Pressable, Text } from 'react-native';
+import { Pressable } from 'react-native';
 
+import { BottomNavigationIcon, bottomNavigationIcons } from '@/components/bottom-navigation-icon';
 import { useTheme } from '@/theme/use-theme';
 
 type LogTabButtonProps = {
@@ -45,12 +46,12 @@ export function LogTabButton({
         zIndex: 1,
       })}
     >
-      <Text
-        selectable
-        style={{ color: colors.accentActionContrast, fontSize: 30, fontWeight: '700', lineHeight: 34 }}
-      >
-        +
-      </Text>
+      <BottomNavigationIcon
+        color={colors.accentActionContrast}
+        name={bottomNavigationIcons.log}
+        size={30}
+        testID="log-tab-icon"
+      />
     </Pressable>
   );
 }


### PR DESCRIPTION
## Summary

DEL-283 adds platform-appropriate vector icons to the authenticated mobile bottom navigation while preserving the established Home, Log, and History structure. Home now uses `chart-line`, History uses `history`, and the existing raised Log action replaces its text plus glyph with the MaterialCommunityIcons `plus` icon.

The navigation previously relied on labels for Home and History and a text glyph for Log, which made the native tab bar less visually scannable than the web navigation. This change uses Expo-compatible MaterialCommunityIcons through `@expo/vector-icons`, centralizes the three semantic icon mappings, and keeps the existing safe-area layout, route behavior, labels, tint states, touch target, and accessibility semantics intact. The icons are decorative so they do not introduce duplicate accessible controls.

## Validation

- `git diff --check`
- `npm run lint`
- `npm run typecheck`
- `npm test` — 16 suites / 86 tests passed
- `npm run config:validate`

The Jest run emitted existing React `act(...)` warnings in unrelated reading-log and dashboard tests, but completed successfully.

## Manual follow-up

Expo Go Android smoke validation remains for review: confirm all three icon meanings, Home and History active/inactive contrast in light and dark system themes, and the raised Log action’s legibility and tappability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent iconography for Home, History, and Log navigation tabs.
  * Replaced the Log tab’s text plus sign with a dedicated icon.
  * Added reusable navigation icon support with configurable color, size, and accessibility identifiers.

* **Tests**
  * Added coverage for navigation icon mappings and rendering.
  * Updated Log tab tests to verify the configured icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->