### PR TITLE
[DEL-285] Refine native Home dashboard

### DIFF
--- a/mobile/src/__tests__/home-dashboard.test.tsx
+++ b/mobile/src/__tests__/home-dashboard.test.tsx
@@ -6,10 +6,12 @@ import HomeScreen from '@/app/(tabs)/home';
 import { useAuthenticatedApi } from '@/auth/auth-context';
 
 const mockRequest = jest.fn();
+const mockNavigate = jest.fn();
 let mockAppStateListener: ((state: 'active' | 'background') => void) | undefined;
 let mockQueryClient: QueryClient | undefined;
 
 jest.mock('@/auth/auth-context', () => ({ useAuthenticatedApi: jest.fn() }));
+jest.mock('expo-router', () => ({ useRouter: () => ({ navigate: mockNavigate }) }));
 jest.mock('react-native/Libraries/Components/RefreshControl/RefreshControl', () => {
   const { View } = jest.requireActual('react-native');
 
@@ -37,7 +39,10 @@ function bootstrap(overrides: Record<string, unknown> = {}) {
       longest_streak: 0,
       this_week_days: 0,
       this_month_days: 0,
-      activity: Array.from({ length: 14 }, (_, index) => ({ date: `2026-07-${String(index + 28).padStart(2, '0')}`, count: 0 })),
+      activity: [
+        ...Array.from({ length: 4 }, (_, index) => ({ date: `2026-07-${String(index + 28).padStart(2, '0')}`, count: 0 })),
+        ...Array.from({ length: 10 }, (_, index) => ({ date: `2026-08-${String(index + 1).padStart(2, '0')}`, count: 0 })),
+      ],
       ...overrides,
     },
   };
@@ -57,13 +62,18 @@ async function renderHome() {
 }
 
 describe('native Home dashboard', () => {
+  let dateTimeFormatSpy: jest.SpiedFunction<typeof Intl.DateTimeFormat>;
+
   beforeEach(() => {
     mockRequest.mockReset();
+    mockNavigate.mockReset();
     mockAppStateListener = undefined;
     jest.mocked(useAuthenticatedApi).mockReturnValue(mockRequest);
+    dateTimeFormatSpy = jest.spyOn(Intl, 'DateTimeFormat');
   });
 
   afterEach(async () => {
+    dateTimeFormatSpy.mockRestore();
     await mockQueryClient?.cancelQueries();
     mockQueryClient?.clear();
   });
@@ -90,7 +100,30 @@ describe('native Home dashboard', () => {
 
     expect(await screen.findByText('No recent reading activity')).toBeOnTheScreen();
     expect(screen.getAllByText('0 days')).toHaveLength(2);
+    expect(screen.getByText('Monday, August 10')).toBeOnTheScreen();
+    expect(dateTimeFormatSpy).toHaveBeenCalledWith('en-CA', {
+      weekday: 'long',
+      month: 'long',
+      day: 'numeric',
+    });
+    expect(screen.getByRole('button', { name: 'Log today’s reading' })).toHaveStyle({
+      backgroundColor: '#f97316',
+    });
+    expect(screen.getByText('Reading rhythm')).toBeOnTheScreen();
+    expect(screen.getByText('Last 14 days')).toBeOnTheScreen();
+    expect(screen.getByLabelText('Legend: Read and No reading')).toBeOnTheScreen();
+    expect(screen.getByLabelText('Tuesday, July 28: No reading')).toBeOnTheScreen();
     expect(mockRequest).toHaveBeenCalledWith('/api/v1/bootstrap');
+  });
+
+  it('opens the existing Log flow only when today has not been read', async () => {
+    mockRequest.mockResolvedValue(bootstrap());
+
+    await renderHome();
+
+    fireEvent.press(await screen.findByRole('button', { name: 'Log today’s reading' }));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/(tabs)/log');
   });
 
   it('renders all supplied dashboard values without recalculating them', async () => {
@@ -108,9 +141,15 @@ describe('native Home dashboard', () => {
     expect(await screen.findByText('Reading logged today')).toBeOnTheScreen();
     expect(screen.getByText('4 days')).toBeOnTheScreen();
     expect(screen.getByText('11 days')).toBeOnTheScreen();
-    expect(screen.getByText('3')).toBeOnTheScreen();
-    expect(screen.getByText('8')).toBeOnTheScreen();
-    expect(screen.getByLabelText('2026-08-14: 2 readings')).toBeOnTheScreen();
+    expect(screen.getByLabelText('Days read this week: 3')).toBeOnTheScreen();
+    expect(screen.getByLabelText('Days read this month: 8')).toBeOnTheScreen();
+    expect(screen.getByText('Best')).toBeOnTheScreen();
+    expect(screen.getByLabelText('Current streak: 4 days. Best: 11 days.')).toHaveStyle({
+      borderWidth: undefined,
+    });
+    expect(screen.getByLabelText('Friday, August 14: Read')).toBeOnTheScreen();
+    expect(screen.getByLabelText('Monday, August 10: No reading. Today')).toHaveStyle({ borderWidth: 2 });
+    expect(screen.queryByRole('button', { name: 'Log today’s reading' })).not.toBeOnTheScreen();
   });
 
   it('offers a recoverable error state', async () => {

--- a/mobile/src/components/home-dashboard.tsx
+++ b/mobile/src/components/home-dashboard.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import { useRouter } from 'expo-router';
 import { useCallback, useEffect } from 'react';
 import {
   AppState,
@@ -16,26 +17,68 @@ import { useAuthenticatedApi } from '@/auth/auth-context';
 import { themeTokens } from '@/theme/tokens';
 import { useTheme } from '@/theme/use-theme';
 
-function StatCard({ label, value }: Readonly<{ label: string; value: string }>) {
+function formatDate(date: string, options: Intl.DateTimeFormatOptions): string {
+  const [year, month, day] = date.split('-').map(Number);
+
+  return new Intl.DateTimeFormat('en-CA', options).format(new Date(year, month - 1, day, 12));
+}
+
+function formatToday(date: string): string {
+  return formatDate(date, { weekday: 'long', month: 'long', day: 'numeric' });
+}
+
+function StreakCard({
+  currentStreak,
+  longestStreak,
+}: Readonly<{ currentStreak: number; longestStreak: number }>) {
   const { colors } = useTheme();
 
   return (
     <View
+      accessible
+      accessibilityLabel={`Current streak: ${currentStreak} ${currentStreak === 1 ? 'day' : 'days'}. Best: ${
+        longestStreak
+      } ${longestStreak === 1 ? 'day' : 'days'}.`}
       style={{
-        flex: 1,
-        minWidth: 130,
         gap: 4,
         padding: themeTokens.spacing.section,
-        borderWidth: 1,
-        borderColor: colors.border,
         borderRadius: themeTokens.radius.card,
         backgroundColor: colors.surface,
       }}
     >
+      <Text selectable style={{ color: colors.mutedText, fontWeight: '600' }}>Current streak</Text>
+      <Text
+        selectable
+        style={{ color: colors.primary, fontSize: 32, fontWeight: '700', fontVariant: ['tabular-nums'] }}
+      >
+        {currentStreak} {currentStreak === 1 ? 'day' : 'days'}
+      </Text>
+      <View style={{ flexDirection: 'row', gap: 4 }}>
+        <Text selectable style={{ color: colors.mutedText }}>Best</Text>
+        <Text
+          selectable
+          style={{ color: colors.text, fontVariant: ['tabular-nums'], fontWeight: '600' }}
+        >
+          {longestStreak} {longestStreak === 1 ? 'day' : 'days'}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+function SupportingStat({ label, value }: Readonly<{ label: string; value: number }>) {
+  const { colors } = useTheme();
+
+  return (
+    <View
+      accessible
+      accessibilityLabel={`${label}: ${value}`}
+      style={{ flex: 1, minWidth: 130, gap: 4, padding: themeTokens.spacing.section }}
+    >
       <Text selectable style={{ color: colors.mutedText }}>{label}</Text>
       <Text
         selectable
-        style={{ color: colors.primary, fontSize: 24, fontWeight: '700', fontVariant: ['tabular-nums'] }}
+        style={{ color: colors.text, fontSize: 20, fontWeight: '700', fontVariant: ['tabular-nums'] }}
       >
         {value}
       </Text>
@@ -43,24 +86,77 @@ function StatCard({ label, value }: Readonly<{ label: string; value: string }>) 
   );
 }
 
-function ActivityStrip({ activity }: Readonly<{ activity: HomeDashboardData['activity'] }>) {
+function ActivityStrip({
+  activity,
+  today,
+}: Readonly<{ activity: HomeDashboardData['activity']; today: string }>) {
   const { colors } = useTheme();
 
   return (
-    <View accessibilityLabel="Reading activity for the last 14 days" style={{ flexDirection: 'row', gap: 6 }}>
-      {activity.map((entry) => (
-        <View
-          key={entry.date}
-          accessible
-          accessibilityLabel={`${entry.date}: ${entry.count} reading${entry.count === 1 ? '' : 's'}`}
-          style={{
-            flex: 1,
-            minHeight: themeTokens.minimumTouchTarget,
-            borderRadius: themeTokens.radius.control,
-            backgroundColor: entry.count > 0 ? colors.primary : colors.border,
-          }}
-        />
-      ))}
+    <View
+      accessibilityLabel="Reading rhythm for the last 14 days. Read and no reading are shown."
+      style={{ gap: 12 }}
+    >
+      <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}>
+        {activity.map((entry) => (
+          <View
+            key={entry.date}
+            accessible
+            accessibilityLabel={`${formatDate(entry.date, { weekday: 'long', month: 'long', day: 'numeric' })}: ${
+              entry.count > 0 ? 'Read' : 'No reading'
+            }${entry.date === today ? '. Today' : ''}`}
+            style={{
+              flexBasis: '12%',
+              flexGrow: 1,
+              minHeight: themeTokens.minimumTouchTarget,
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 2,
+              paddingVertical: 6,
+              borderWidth: entry.date === today ? 2 : 1,
+              borderColor: entry.date === today ? colors.accent : colors.border,
+              borderRadius: themeTokens.radius.control,
+              backgroundColor: entry.count > 0 ? colors.primary : colors.primarySubtle,
+            }}
+          >
+            <Text
+              selectable
+              style={{ color: entry.count > 0 ? colors.primaryContrast : colors.mutedText, fontSize: 12 }}
+            >
+              {formatDate(entry.date, { weekday: 'narrow' })}
+            </Text>
+            <Text
+              selectable
+              style={{
+                color: entry.count > 0 ? colors.primaryContrast : colors.text,
+                fontWeight: '700',
+                fontVariant: ['tabular-nums'],
+              }}
+            >
+              {formatDate(entry.date, { day: 'numeric' })}
+            </Text>
+          </View>
+        ))}
+      </View>
+      <View accessibilityLabel="Legend: Read and No reading" style={{ flexDirection: 'row', gap: 16 }}>
+        <View style={{ alignItems: 'center', flexDirection: 'row', gap: 6 }}>
+          <View style={{ width: 12, height: 12, borderRadius: 6, backgroundColor: colors.primary }} />
+          <Text selectable style={{ color: colors.mutedText }}>Read</Text>
+        </View>
+        <View style={{ alignItems: 'center', flexDirection: 'row', gap: 6 }}>
+          <View
+            style={{
+              width: 12,
+              height: 12,
+              borderWidth: 1,
+              borderColor: colors.border,
+              borderRadius: 6,
+              backgroundColor: colors.primarySubtle,
+            }}
+          />
+          <Text selectable style={{ color: colors.mutedText }}>No reading</Text>
+        </View>
+      </View>
     </View>
   );
 }
@@ -79,6 +175,7 @@ function LoadingState() {
 export function HomeDashboard() {
   const { colors } = useTheme();
   const request = useAuthenticatedApi();
+  const router = useRouter();
   const { data, isPending, isRefetchError, isRefetching, refetch } = useQuery({
     queryKey: ['bootstrap'],
     queryFn: () => fetchBootstrap(request),
@@ -159,7 +256,9 @@ export function HomeDashboard() {
           backgroundColor: colors.surface,
         }}
       >
-        <Text selectable style={{ color: colors.mutedText, fontWeight: '600' }}>Today · {dashboard.today}</Text>
+        <Text selectable style={{ color: colors.mutedText, fontWeight: '600' }}>
+          {formatToday(dashboard.today)}
+        </Text>
         <Text
           selectable
           style={{ color: dashboard.has_read_today ? colors.success : colors.text, fontSize: 24, fontWeight: '700' }}
@@ -169,6 +268,26 @@ export function HomeDashboard() {
         <Text selectable style={{ color: colors.mutedText }}>
           {dashboard.has_read_today ? 'Your reading is safely recorded.' : 'Log today’s reading to keep your journey moving.'}
         </Text>
+        {!dashboard.has_read_today ? (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Log today’s reading"
+            accessibilityHint="Opens the reading log for today"
+            onPress={() => router.navigate('/(tabs)/log')}
+            style={{
+              alignSelf: 'flex-start',
+              minHeight: themeTokens.minimumTouchTarget,
+              justifyContent: 'center',
+              paddingHorizontal: themeTokens.spacing.section,
+              borderRadius: themeTokens.radius.control,
+              backgroundColor: colors.accentAction,
+            }}
+          >
+            <Text selectable style={{ color: colors.accentActionContrast, fontWeight: '700' }}>
+              Log today’s reading
+            </Text>
+          </Pressable>
+        ) : null}
       </View>
 
       {isRefetchError ? (
@@ -214,21 +333,23 @@ export function HomeDashboard() {
         <View accessibilityLiveRegion="polite" style={{ gap: 8 }}>
           <Text selectable style={{ color: colors.text, fontSize: 20, fontWeight: '700' }}>No recent reading activity</Text>
           <Text selectable style={{ color: colors.mutedText }}>
-            Log a reading to start a new streak and fill your activity strip.
+            Log a reading to start a new streak and begin your reading rhythm.
           </Text>
         </View>
       ) : null}
 
-      <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: themeTokens.spacing.section }}>
-        <StatCard label="Current streak" value={`${dashboard.current_streak} days`} />
-        <StatCard label="Longest streak" value={`${dashboard.longest_streak} days`} />
-        <StatCard label="Days read this week" value={`${dashboard.this_week_days}`} />
-        <StatCard label="Days read this month" value={`${dashboard.this_month_days}`} />
+      <View style={{ gap: 8 }}>
+        <StreakCard currentStreak={dashboard.current_streak} longestStreak={dashboard.longest_streak} />
+        <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: themeTokens.spacing.section }}>
+          <SupportingStat label="Days read this week" value={dashboard.this_week_days} />
+          <SupportingStat label="Days read this month" value={dashboard.this_month_days} />
+        </View>
       </View>
 
       <View style={{ gap: 8 }}>
-        <Text selectable style={{ color: colors.text, fontSize: 20, fontWeight: '700' }}>Recent activity</Text>
-        <ActivityStrip activity={dashboard.activity} />
+        <Text selectable style={{ color: colors.text, fontSize: 20, fontWeight: '700' }}>Reading rhythm</Text>
+        <Text selectable style={{ color: colors.mutedText }}>Last 14 days</Text>
+        <ActivityStrip activity={dashboard.activity} today={dashboard.today} />
       </View>
     </ScrollView>
   );


### PR DESCRIPTION
## Summary

Refines the native Home dashboard for clearer Android dogfood use:

- makes Today and Current streak visually cohesive, with the streak as the primary statistic and Best as supporting context
- adds an explicit orange Log today action when no reading exists, while preserving the existing raised Log navigation action
- replaces the anonymous activity strip with a date-anchored 14-day Reading rhythm, Read / No reading legend, and distinct today treatment
- fixes Home dates to English Canadian formatting so English-only app copy is not mixed with a device-language date

No backend data, client-side business calculations, navigation redesign, or release configuration changes were introduced.

## Verification

- `npm ci`
- `npm run lint`
- `npm run typecheck`
- `npm test` — 87 passing tests
- `npm run config:validate`
- `git diff --check`

## Manual follow-up

Expo Go Android validation is still needed in light/dark mode and with larger system text, including the today CTA, rhythm grid, bottom-navigation clearance, and refresh behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a 14-day reading activity grid with date labels, today highlighting, and a legend.
  - Added separate streak and activity statistic cards.
  - Added a button to log today’s reading when no entry exists.
  - Improved date formatting for clearer dashboard information.

- **Accessibility**
  - Expanded labels and metadata for dashboard metrics, reading activity, and navigation controls.
  - Updated headings and empty-state messaging for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->