### PR TITLE
[DEL-286] Show active account identity and demote sign out

### DIFF
--- a/mobile/AGENTS.md
+++ b/mobile/AGENTS.md
@@ -22,6 +22,15 @@ These instructions apply to every file under `/mobile` and supplement the reposi
 - Route files live only in `src/app`. Put components, hooks, configuration, state, types, and utilities outside the router tree.
 - Use kebab-case file names and the `@/` path alias instead of deep relative imports.
 - Prefer small reusable components and centralized tokens over duplicated inline values.
+- Before creating a component, look at the rest of the mobile codebase for an existing one that already owns the
+  same chrome, motion, interaction, or visual pattern.
+- If an existing component is almost identical and only the body, title, or accessibility labels differ, extract
+  the shared shell and reuse it. Do not duplicate that pattern in a new file, and do not ask first.
+- If an existing candidate is the right shape but is below the quality you would otherwise ship — unclear API,
+  weak accessibility, hard-coded values, or hard to extend — ask whether to improve and extract that component
+  or keep a new single-use component for this case.
+- Keep feature-specific content in the caller. Shared components should own the repeated shell, motion, and
+  accessibility chrome.
 - Keep source lines at or below 120 characters where practical. Expand dense JSX props and inline React Native
   style objects across multiple lines instead of compressing a component onto one line.
 - Keep dynamic styles close to the component that owns them, but extract named helpers when conditional

--- a/mobile/src/__tests__/account-menu.test.tsx
+++ b/mobile/src/__tests__/account-menu.test.tsx
@@ -1,0 +1,185 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import type { PropsWithChildren } from 'react';
+import { AccessibilityInfo } from 'react-native';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+
+import { ApiError } from '@/api/api-error';
+import { AccountMenu, accountInitials } from '@/components/account-menu';
+import { useAuth, useAuthenticatedApi } from '@/auth/auth-context';
+
+jest.mock('@/auth/auth-context', () => ({
+  useAuth: jest.fn(),
+  useAuthenticatedApi: jest.fn(),
+}));
+
+const request = jest.fn();
+const logout = jest.fn();
+let queryClient: QueryClient;
+
+const sessionUser = { id: 1, name: 'Reader', email: 'reader@example.com' };
+
+function bootstrap(overrides: Record<string, unknown> = {}) {
+  return {
+    data: {
+      user: { id: 2, name: 'Restored Reader', email: 'restored@example.com' },
+      today: '2026-08-10',
+      yesterday: '2026-08-09',
+      books: [],
+      recent_book_ids: [],
+      has_read_today: false,
+      current_streak: 0,
+      longest_streak: 0,
+      this_week_days: 0,
+      this_month_days: 0,
+      activity: [],
+      ...overrides,
+    },
+  };
+}
+
+function mockAuth(user: typeof sessionUser | null = sessionUser) {
+  jest.mocked(useAuth).mockReturnValue({
+    user,
+    logout,
+    isLoggingOut: false,
+  } as unknown as ReturnType<typeof useAuth>);
+}
+
+async function renderMenu() {
+  queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { gcTime: 0, retry: false },
+      mutations: { gcTime: 0, retry: false },
+    },
+  });
+
+  function Wrapper({ children }: PropsWithChildren) {
+    return (
+      <SafeAreaProvider
+        initialMetrics={{
+          frame: { x: 0, y: 0, width: 390, height: 844 },
+          insets: { top: 47, left: 0, right: 0, bottom: 34 },
+        }}
+      >
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      </SafeAreaProvider>
+    );
+  }
+
+  return render(<AccountMenu />, { wrapper: Wrapper });
+}
+
+describe('account initials', () => {
+  it('uses the first and last name letters', () => {
+    expect(accountInitials('Orlando Villanueva')).toBe('OV');
+    expect(accountInitials('Reader')).toBe('R');
+    expect(accountInitials('  Jean Luc Picard  ')).toBe('JP');
+    expect(accountInitials('   ')).toBeNull();
+    expect(accountInitials(undefined)).toBeNull();
+  });
+});
+
+describe('account menu', () => {
+  beforeEach(() => {
+    request.mockReset();
+    logout.mockReset();
+    logout.mockResolvedValue(undefined);
+    request.mockResolvedValue(bootstrap());
+    jest.mocked(useAuthenticatedApi).mockReturnValue(request);
+    mockAuth();
+  });
+
+  afterEach(async () => {
+    await queryClient?.cancelQueries();
+    queryClient?.clear();
+    cleanup();
+  });
+
+  it('keeps sign out hidden until the account control is opened', async () => {
+    await renderMenu();
+
+    expect(screen.getByLabelText('Account for Reader')).toBeOnTheScreen();
+    expect(screen.getByLabelText('Account for Reader')).toHaveProp(
+      'accessibilityHint',
+      'Shows the signed-in account and sign out',
+    );
+    expect(screen.getByText('R')).toBeOnTheScreen();
+    expect(screen.queryByLabelText('Sign out')).not.toBeOnTheScreen();
+    expect(screen.queryByText('Log out')).not.toBeOnTheScreen();
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it('shows the signed-in name and email from the auth session', async () => {
+    await renderMenu();
+
+    await fireEvent.press(screen.getByLabelText('Account for Reader'));
+
+    expect(screen.getByText('Reader')).toBeOnTheScreen();
+    expect(screen.getByText('reader@example.com')).toBeOnTheScreen();
+    expect(screen.getByLabelText('Sign out')).toBeOnTheScreen();
+    expect(AccessibilityInfo.announceForAccessibility).toHaveBeenCalledWith(
+      'Signed in as Reader, reader@example.com.',
+    );
+  });
+
+  it('reads restored identity from bootstrap when the session has no user', async () => {
+    mockAuth(null);
+    let resolveBootstrap: (value: ReturnType<typeof bootstrap>) => void = () => undefined;
+    request.mockReturnValue(new Promise((resolve) => {
+      resolveBootstrap = resolve;
+    }));
+    await renderMenu();
+
+    expect(screen.getByLabelText('Account')).toBeOnTheScreen();
+    await fireEvent.press(screen.getByLabelText('Account'));
+    expect(screen.getByText('Loading account…')).toBeOnTheScreen();
+    expect(screen.getByLabelText('Sign out')).toBeOnTheScreen();
+
+    await act(async () => {
+      resolveBootstrap(bootstrap());
+    });
+
+    await waitFor(() => expect(screen.getByText('Restored Reader')).toBeOnTheScreen());
+    expect(screen.getByText('restored@example.com')).toBeOnTheScreen();
+    expect(request).toHaveBeenCalledWith('/api/v1/bootstrap');
+  });
+
+  it('dismisses the account surface from the overlay and close control', async () => {
+    await renderMenu();
+
+    await fireEvent.press(screen.getByLabelText('Account for Reader'));
+    expect(screen.getByText('reader@example.com')).toBeOnTheScreen();
+
+    await fireEvent.press(screen.getByLabelText('Dismiss account'));
+    expect(screen.queryByText('reader@example.com')).not.toBeOnTheScreen();
+    expect(screen.queryByLabelText('Sign out')).not.toBeOnTheScreen();
+
+    await fireEvent.press(screen.getByLabelText('Account for Reader'));
+    await fireEvent.press(screen.getByLabelText('Close account'));
+    expect(screen.queryByText('reader@example.com')).not.toBeOnTheScreen();
+  });
+
+  it('signs out from the opened account surface', async () => {
+    await renderMenu();
+
+    await fireEvent.press(screen.getByLabelText('Account for Reader'));
+    await fireEvent.press(screen.getByLabelText('Sign out'));
+
+    expect(logout).toHaveBeenCalled();
+    expect(AccessibilityInfo.announceForAccessibility).toHaveBeenCalledWith('Signing out.');
+  });
+
+  it('keeps sign out available when restored identity cannot load', async () => {
+    mockAuth(null);
+    request.mockRejectedValue(new ApiError('Delight could not connect.', 'network'));
+    await renderMenu();
+
+    await fireEvent.press(screen.getByLabelText('Account'));
+    expect(await screen.findByText('Account details are unavailable.')).toBeOnTheScreen();
+    expect(screen.getByLabelText('Sign out')).toBeOnTheScreen();
+
+    await fireEvent.press(screen.getByLabelText('Sign out'));
+    expect(logout).toHaveBeenCalled();
+  });
+});

--- a/mobile/src/__tests__/bottom-sheet.test.tsx
+++ b/mobile/src/__tests__/bottom-sheet.test.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { Text } from 'react-native';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+
+import { BottomSheet, sheetPaddingBottom } from '@/components/bottom-sheet';
+import { themeTokens } from '@/theme/tokens';
+
+async function renderSheet(visible = true, onClose = jest.fn()) {
+  await render(
+    <SafeAreaProvider
+      initialMetrics={{
+        frame: { x: 0, y: 0, width: 390, height: 844 },
+        insets: { top: 47, left: 0, right: 0, bottom: 34 },
+      }}
+    >
+      <BottomSheet
+        visible={visible}
+        title="Choose a book"
+        onClose={onClose}
+        dismissAccessibilityLabel="Dismiss book list"
+        dismissAccessibilityHint="Closes the Bible book list"
+        closeAccessibilityLabel="Close book list"
+        closeAccessibilityHint="Closes the Bible book list"
+      >
+        <Text>Sheet body</Text>
+      </BottomSheet>
+    </SafeAreaProvider>,
+  );
+
+  return { onClose };
+}
+
+describe('bottom sheet padding', () => {
+  it('keeps default chrome padding, honors an override, and only grows for an explicit safe-area inset', () => {
+    expect(sheetPaddingBottom({ padBottomSafeArea: false, insetBottom: 48 })).toBe(
+      themeTokens.spacing.screen,
+    );
+    expect(sheetPaddingBottom({ padBottomSafeArea: true, insetBottom: 48 })).toBe(48);
+    expect(sheetPaddingBottom({ padBottomSafeArea: true, insetBottom: 8 })).toBe(
+      themeTokens.spacing.screen,
+    );
+    expect(sheetPaddingBottom({
+      padBottomSafeArea: false,
+      paddingBottom: 0,
+      insetBottom: 48,
+    })).toBe(0);
+  });
+});
+
+describe('bottom sheet', () => {
+  it('renders the shared chrome and body when visible', async () => {
+    await renderSheet();
+
+    expect(screen.getByText('Choose a book')).toBeOnTheScreen();
+    expect(screen.getByText('Sheet body')).toBeOnTheScreen();
+    expect(screen.getByLabelText('Close book list')).toBeOnTheScreen();
+    expect(screen.getByLabelText('Dismiss book list')).toBeOnTheScreen();
+  });
+
+  it('hides the sheet when it is not visible', async () => {
+    await renderSheet(false);
+
+    expect(screen.queryByText('Choose a book')).not.toBeOnTheScreen();
+    expect(screen.queryByText('Sheet body')).not.toBeOnTheScreen();
+  });
+
+  it('closes from the overlay and the close control', async () => {
+    const { onClose } = await renderSheet();
+
+    await fireEvent.press(screen.getByLabelText('Dismiss book list'));
+    await fireEvent.press(screen.getByLabelText('Close book list'));
+
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+});

--- a/mobile/src/__tests__/reading-log-form.test.tsx
+++ b/mobile/src/__tests__/reading-log-form.test.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 import type { PropsWithChildren } from 'react';
 import { AccessibilityInfo, AppState, Keyboard, ScrollView } from 'react-native';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import { ApiError } from '@/api/api-error';
 import LogScreen from '@/app/(tabs)/log';
@@ -78,7 +79,16 @@ async function renderLog() {
   });
 
   function Wrapper({ children }: PropsWithChildren) {
-    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+    return (
+      <SafeAreaProvider
+        initialMetrics={{
+          frame: { x: 0, y: 0, width: 390, height: 844 },
+          insets: { top: 47, left: 0, right: 0, bottom: 34 },
+        }}
+      >
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      </SafeAreaProvider>
+    );
   }
 
   return render(<LogScreen />, { wrapper: Wrapper });

--- a/mobile/src/__tests__/reading-log-form.test.tsx
+++ b/mobile/src/__tests__/reading-log-form.test.tsx
@@ -201,9 +201,14 @@ describe('native reading-log form', () => {
 
     await waitFor(() => {
       expect(request).toHaveBeenCalledTimes(2);
-      expect(screen.getByLabelText('Yesterday')).toHaveProp('accessibilityState', { selected: true });
-      expect(screen.getByLabelText('Today')).toHaveProp('accessibilityState', { selected: false });
+      expect(screen.getByLabelText('Yesterday')).toHaveProp(
+        'accessibilityHint',
+        'Uses the server date 2026-08-10',
+      );
     });
+
+    expect(screen.getByLabelText('Today')).toHaveProp('accessibilityState', { selected: false });
+    expect(screen.getByLabelText('Yesterday')).toHaveProp('accessibilityState', { selected: false });
   });
 
   it('prefers a valid recent book and describes that book’s chapter count', async () => {

--- a/mobile/src/__tests__/tab-screens.test.tsx
+++ b/mobile/src/__tests__/tab-screens.test.tsx
@@ -1,6 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { cleanup, render, screen } from '@testing-library/react-native';
 import type { PropsWithChildren } from 'react';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import LogScreen from '@/app/(tabs)/log';
 import { useAuthenticatedApi } from '@/auth/auth-context';
@@ -50,7 +51,16 @@ describe('mobile tab screens', () => {
     });
 
     function Wrapper({ children }: PropsWithChildren) {
-      return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+      return (
+        <SafeAreaProvider
+          initialMetrics={{
+            frame: { x: 0, y: 0, width: 390, height: 844 },
+            insets: { top: 47, left: 0, right: 0, bottom: 34 },
+          }}
+        >
+          <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+        </SafeAreaProvider>
+      );
     }
 
     await render(<LogScreen />, { wrapper: Wrapper });

--- a/mobile/src/components/account-menu.tsx
+++ b/mobile/src/components/account-menu.tsx
@@ -1,0 +1,180 @@
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { useQuery } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
+import { AccessibilityInfo, Pressable, Text, View } from 'react-native';
+
+import { fetchBootstrap } from '@/api/bootstrap';
+import { useAuth, useAuthenticatedApi, type AuthUser } from '@/auth/auth-context';
+import { BottomSheet } from '@/components/bottom-sheet';
+import { LogoutButton } from '@/components/logout-button';
+import { themeTokens } from '@/theme/tokens';
+import { useTheme } from '@/theme/use-theme';
+
+export function accountInitials(name: string | undefined): string | null {
+  if (!name) {
+    return null;
+  }
+
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+
+  if (parts.length === 0) {
+    return null;
+  }
+
+  const first = [...parts[0]][0];
+
+  if (!first) {
+    return null;
+  }
+
+  if (parts.length === 1) {
+    return first.toLocaleUpperCase('en-CA');
+  }
+
+  const last = [...parts[parts.length - 1]][0];
+
+  if (!last) {
+    return null;
+  }
+
+  return `${first}${last}`.toLocaleUpperCase('en-CA');
+}
+
+function accountAccessibilityLabel(user: AuthUser | null): string {
+  return user?.name ? `Account for ${user.name}` : 'Account';
+}
+
+function identityAnnouncement(user: AuthUser | null, isLoading: boolean): string {
+  if (user) {
+    return `Signed in as ${user.name}, ${user.email}.`;
+  }
+
+  if (isLoading) {
+    return 'Loading account.';
+  }
+
+  return 'Account details are unavailable.';
+}
+
+export function AccountMenu() {
+  const { user: sessionUser } = useAuth();
+  const request = useAuthenticatedApi();
+  const { colors } = useTheme();
+  const [visible, setVisible] = useState(false);
+  const { data, isLoading } = useQuery({
+    queryKey: ['bootstrap'],
+    queryFn: () => fetchBootstrap(request),
+    enabled: sessionUser === null,
+  });
+  const user = sessionUser ?? data?.user ?? null;
+  const isIdentityLoading = !user && isLoading;
+  const initials = accountInitials(user?.name);
+
+  useEffect(() => {
+    if (!visible) {
+      return;
+    }
+
+    AccessibilityInfo.announceForAccessibility(identityAnnouncement(user, isIdentityLoading));
+  }, [isIdentityLoading, user, visible]);
+
+  function close() {
+    setVisible(false);
+  }
+
+  return (
+    <>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={accountAccessibilityLabel(user)}
+        accessibilityHint="Shows the signed-in account and sign out"
+        accessibilityState={{ expanded: visible }}
+        onPress={() => setVisible(true)}
+        style={{
+          minWidth: themeTokens.minimumTouchTarget,
+          minHeight: themeTokens.minimumTouchTarget,
+          alignItems: 'center',
+          justifyContent: 'center',
+          paddingHorizontal: 8,
+        }}
+      >
+        <View
+          accessible={false}
+          style={{
+            minWidth: 32,
+            minHeight: 32,
+            alignItems: 'center',
+            justifyContent: 'center',
+            paddingHorizontal: 6,
+            borderRadius: 16,
+            backgroundColor: colors.primarySubtle,
+          }}
+        >
+          {initials ? (
+            <Text
+              accessible={false}
+              adjustsFontSizeToFit
+              minimumFontScale={0.7}
+              numberOfLines={1}
+              style={{
+                color: colors.primary,
+                fontSize: 13,
+                fontWeight: '700',
+              }}
+            >
+              {initials}
+            </Text>
+          ) : (
+            <MaterialCommunityIcons
+              accessible={false}
+              color={colors.primary}
+              name="account"
+              size={20}
+            />
+          )}
+        </View>
+      </Pressable>
+      <BottomSheet
+        visible={visible}
+        title="Account"
+        onClose={close}
+        padBottomSafeArea
+        dismissAccessibilityLabel="Dismiss account"
+        dismissAccessibilityHint="Closes the account details"
+        closeAccessibilityLabel="Close account"
+        closeAccessibilityHint="Closes the account details"
+      >
+        <View accessibilityLiveRegion="polite" style={{ gap: 4 }}>
+          {user ? (
+            <>
+              <Text
+                selectable
+                style={{ color: colors.text, fontSize: 18, fontWeight: '700' }}
+              >
+                {user.name}
+              </Text>
+              <Text selectable style={{ color: colors.mutedText, fontSize: 16 }}>
+                {user.email}
+              </Text>
+            </>
+          ) : (
+            <Text selectable style={{ color: colors.mutedText, fontSize: 16 }}>
+              {isIdentityLoading
+                ? 'Loading account…'
+                : 'Account details are unavailable.'}
+            </Text>
+          )}
+        </View>
+        <View
+          style={{
+            borderTopWidth: 1,
+            borderTopColor: colors.border,
+            paddingTop: 8,
+          }}
+        >
+          <LogoutButton />
+        </View>
+      </BottomSheet>
+    </>
+  );
+}

--- a/mobile/src/components/book-picker-modal.tsx
+++ b/mobile/src/components/book-picker-modal.tsx
@@ -1,22 +1,12 @@
-import { useEffect, useState } from 'react';
-import {
-  Animated,
-  Modal,
-  Pressable,
-  ScrollView,
-  Text,
-  useWindowDimensions,
-  View,
-} from 'react-native';
+import { useState } from 'react';
+import { Pressable, ScrollView, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import type { BootstrapBook } from '@/api/bootstrap';
+import { BottomSheet } from '@/components/bottom-sheet';
 import { booksByTestament, chapterCountLabel, testamentLabel } from '@/features/reading-log/form';
 import { themeTokens } from '@/theme/tokens';
 import { useTheme } from '@/theme/use-theme';
-
-const overlayColor = 'rgba(15, 23, 42, 0.48)';
-const overlayEnterMs = 200;
-const sheetEnterMs = 280;
 
 function selectedTestament(
   books: readonly BootstrapBook[],
@@ -41,36 +31,11 @@ export function BookPickerModal({
   onSelect,
 }: Readonly<BookPickerModalProps>) {
   const { colors } = useTheme();
-  const { height } = useWindowDimensions();
-  const [overlayOpacity] = useState(() => new Animated.Value(0));
-  const [sheetTranslateY] = useState(() => new Animated.Value(height));
+  const insets = useSafeAreaInsets();
   const [activeTestamentOverride, setActiveTestamentOverride] = useState<string | null>(null);
   const availableTestaments = booksByTestament(books);
   const activeTestament = activeTestamentOverride ?? selectedTestament(books, selectedBookId);
   const activeBooks = availableTestaments.find(([testament]) => testament === activeTestament)?.[1] ?? [];
-
-  useEffect(() => {
-    if (!visible) {
-      return;
-    }
-
-    const offscreen = height;
-    overlayOpacity.setValue(0);
-    sheetTranslateY.setValue(offscreen);
-
-    Animated.parallel([
-      Animated.timing(overlayOpacity, {
-        toValue: 1,
-        duration: overlayEnterMs,
-        useNativeDriver: true,
-      }),
-      Animated.timing(sheetTranslateY, {
-        toValue: 0,
-        duration: sheetEnterMs,
-        useNativeDriver: true,
-      }),
-    ]).start();
-  }, [height, overlayOpacity, sheetTranslateY, visible]);
 
   function close() {
     setActiveTestamentOverride(null);
@@ -83,143 +48,87 @@ export function BookPickerModal({
   }
 
   return (
-    <Modal
-      animationType="none"
-      transparent
+    <BottomSheet
       visible={visible}
-      onRequestClose={close}
-      accessibilityViewIsModal
+      title="Choose a book"
+      onClose={close}
+      maxHeight="80%"
+      paddingBottom={0}
+      dismissAccessibilityLabel="Dismiss book list"
+      dismissAccessibilityHint="Closes the Bible book list"
+      closeAccessibilityLabel="Close book list"
+      closeAccessibilityHint="Closes the Bible book list"
     >
-      <View style={{ flex: 1, justifyContent: 'flex-end' }}>
-        <Animated.View
-          pointerEvents="none"
-          style={{
-            position: 'absolute',
-            top: 0,
-            right: 0,
-            bottom: 0,
-            left: 0,
-            backgroundColor: overlayColor,
-            opacity: overlayOpacity,
-          }}
-        />
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel="Dismiss book list"
-          accessibilityHint="Closes the Bible book list"
-          onPress={close}
-          style={{ position: 'absolute', top: 0, right: 0, bottom: 0, left: 0 }}
-        />
-        <Animated.View
-          style={{
-            maxHeight: '80%',
-            padding: themeTokens.spacing.screen,
-            borderTopLeftRadius: themeTokens.radius.card,
-            borderTopRightRadius: themeTokens.radius.card,
-            borderCurve: 'continuous',
-            backgroundColor: colors.surface,
-            transform: [{ translateY: sheetTranslateY }],
-          }}
-        >
-          <View
-            style={{
-              flexDirection: 'row',
-              alignItems: 'center',
-              justifyContent: 'space-between',
-              gap: 12,
-            }}
-          >
-            <Text selectable style={{ color: colors.text, fontSize: 20, fontWeight: '700', flex: 1 }}>
-              Choose a book
-            </Text>
+      <View
+        accessibilityRole="tablist"
+        style={{
+          flexDirection: 'row',
+          padding: 4,
+          borderRadius: themeTokens.radius.control,
+          backgroundColor: colors.input,
+        }}
+      >
+        {availableTestaments.map(([testament]) => {
+          const isSelected = testament === activeTestament;
+          const label = testamentLabel(testament);
+
+          return (
             <Pressable
-              accessibilityRole="button"
-              accessibilityLabel="Close book list"
-              accessibilityHint="Closes the Bible book list"
-              onPress={close}
+              key={testament}
+              accessibilityRole="tab"
+              accessibilityLabel={`Show ${label} books`}
+              accessibilityState={{ selected: isSelected }}
+              onPress={() => setActiveTestamentOverride(testament)}
               style={{
+                flex: 1,
                 minHeight: themeTokens.minimumTouchTarget,
-                minWidth: themeTokens.minimumTouchTarget,
+                alignItems: 'center',
                 justifyContent: 'center',
+                paddingHorizontal: 6,
+                borderRadius: themeTokens.radius.control - 4,
+                backgroundColor: isSelected ? colors.surface : 'transparent',
               }}
             >
-              <Text style={{ color: colors.primary, fontSize: 16, fontWeight: '600' }}>Close</Text>
-            </Pressable>
-          </View>
-          <View
-            accessibilityRole="tablist"
-            style={{
-              flexDirection: 'row',
-              marginTop: themeTokens.spacing.section,
-              padding: 4,
-              borderRadius: themeTokens.radius.control,
-              backgroundColor: colors.input,
-            }}
-          >
-            {availableTestaments.map(([testament]) => {
-              const isSelected = testament === activeTestament;
-              const label = testamentLabel(testament);
-
-              return (
-                <Pressable
-                  key={testament}
-                  accessibilityRole="tab"
-                  accessibilityLabel={`Show ${label} books`}
-                  accessibilityState={{ selected: isSelected }}
-                  onPress={() => setActiveTestamentOverride(testament)}
-                  style={{
-                    flex: 1,
-                    minHeight: themeTokens.minimumTouchTarget,
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    paddingHorizontal: 6,
-                    borderRadius: themeTokens.radius.control - 4,
-                    backgroundColor: isSelected ? colors.surface : 'transparent',
-                  }}
-                >
-                  <Text
-                    style={{
-                      color: isSelected ? colors.primary : colors.mutedText,
-                      fontSize: 13,
-                      fontWeight: '700',
-                      textAlign: 'center',
-                    }}
-                  >
-                    {label}
-                  </Text>
-                </Pressable>
-              );
-            })}
-          </View>
-          <ScrollView
-            keyboardShouldPersistTaps="handled"
-            style={{ marginTop: themeTokens.spacing.section }}
-            contentContainerStyle={{ gap: 8, paddingBottom: 24 }}
-          >
-            {activeBooks.map((book) => (
-              <Pressable
-                key={book.id}
-                accessibilityRole="button"
-                accessibilityLabel={book.name}
-                accessibilityHint={`Selects ${book.name}. ${chapterCountLabel(book)}`}
-                accessibilityState={{ selected: selectedBookId === book.id }}
-                onPress={() => selectBook(book)}
+              <Text
                 style={{
-                  minHeight: themeTokens.minimumTouchTarget,
-                  justifyContent: 'center',
-                  paddingHorizontal: 12,
-                  borderWidth: 1,
-                  borderColor: selectedBookId === book.id ? colors.primary : colors.border,
-                  borderRadius: themeTokens.radius.control,
-                  backgroundColor: selectedBookId === book.id ? colors.primarySubtle : colors.input,
+                  color: isSelected ? colors.primary : colors.mutedText,
+                  fontSize: 13,
+                  fontWeight: '700',
+                  textAlign: 'center',
                 }}
               >
-                <Text style={{ color: colors.text, fontSize: 16 }}>{book.name}</Text>
-              </Pressable>
-            ))}
-          </ScrollView>
-        </Animated.View>
+                {label}
+              </Text>
+            </Pressable>
+          );
+        })}
       </View>
-    </Modal>
+      <ScrollView
+        keyboardShouldPersistTaps="handled"
+        contentContainerStyle={{ gap: 8, paddingBottom: Math.max(insets.bottom, 8) }}
+      >
+        {activeBooks.map((book) => (
+          <Pressable
+            key={book.id}
+            accessibilityRole="button"
+            accessibilityLabel={book.name}
+            accessibilityHint={`Selects ${book.name}. ${chapterCountLabel(book)}`}
+            accessibilityState={{ selected: selectedBookId === book.id }}
+            onPress={() => selectBook(book)}
+            style={{
+              minHeight: themeTokens.minimumTouchTarget,
+              justifyContent: 'center',
+              paddingHorizontal: 12,
+              borderWidth: 1,
+              borderColor: selectedBookId === book.id ? colors.primary : colors.border,
+              borderRadius: themeTokens.radius.control,
+              backgroundColor: selectedBookId === book.id ? colors.primarySubtle : colors.input,
+            }}
+          >
+            <Text style={{ color: colors.text, fontSize: 16 }}>{book.name}</Text>
+          </Pressable>
+        ))}
+      </ScrollView>
+    </BottomSheet>
   );
 }

--- a/mobile/src/components/bottom-sheet.tsx
+++ b/mobile/src/components/bottom-sheet.tsx
@@ -1,0 +1,185 @@
+import { type ReactNode, useEffect, useState } from 'react';
+import {
+  Animated,
+  type DimensionValue,
+  Modal,
+  Pressable,
+  Text,
+  useWindowDimensions,
+  View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { themeTokens } from '@/theme/tokens';
+import { useTheme } from '@/theme/use-theme';
+
+const overlayColor = 'rgba(15, 23, 42, 0.48)';
+const overlayEnterMs = 200;
+const sheetEnterMs = 280;
+
+type BottomSheetProps = {
+  visible: boolean;
+  title: string;
+  onClose: () => void;
+  children: ReactNode;
+  dismissAccessibilityLabel: string;
+  dismissAccessibilityHint: string;
+  closeAccessibilityLabel: string;
+  closeAccessibilityHint: string;
+  maxHeight?: DimensionValue;
+  /**
+   * Reserve extra space below chrome for the system gesture inset.
+   * Leave off for tall scrollable sheets so the list can sit closer to the bottom.
+   */
+  padBottomSafeArea?: boolean;
+  paddingBottom?: number;
+};
+
+export function sheetPaddingBottom({
+  padBottomSafeArea,
+  paddingBottom,
+  insetBottom,
+}: {
+  padBottomSafeArea: boolean;
+  paddingBottom?: number;
+  insetBottom: number;
+}): number {
+  if (paddingBottom !== undefined) {
+    return paddingBottom;
+  }
+
+  if (!padBottomSafeArea) {
+    return themeTokens.spacing.screen;
+  }
+
+  return Math.max(insetBottom, themeTokens.spacing.screen);
+}
+
+export function BottomSheet({
+  visible,
+  title,
+  onClose,
+  children,
+  dismissAccessibilityLabel,
+  dismissAccessibilityHint,
+  closeAccessibilityLabel,
+  closeAccessibilityHint,
+  maxHeight,
+  padBottomSafeArea = false,
+  paddingBottom,
+}: Readonly<BottomSheetProps>) {
+  const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
+  const { height } = useWindowDimensions();
+  const [overlayOpacity] = useState(() => new Animated.Value(0));
+  const [sheetTranslateY] = useState(() => new Animated.Value(height));
+
+  useEffect(() => {
+    if (!visible) {
+      return;
+    }
+
+    overlayOpacity.setValue(0);
+    sheetTranslateY.setValue(height);
+
+    Animated.parallel([
+      Animated.timing(overlayOpacity, {
+        toValue: 1,
+        duration: overlayEnterMs,
+        useNativeDriver: true,
+      }),
+      Animated.timing(sheetTranslateY, {
+        toValue: 0,
+        duration: sheetEnterMs,
+        useNativeDriver: true,
+      }),
+    ]).start();
+  }, [height, overlayOpacity, sheetTranslateY, visible]);
+
+  return (
+    <Modal
+      animationType="none"
+      transparent
+      visible={visible}
+      onRequestClose={onClose}
+      accessibilityViewIsModal
+    >
+      <View style={{ flex: 1, justifyContent: 'flex-end' }}>
+        <Animated.View
+          pointerEvents="none"
+          style={{
+            position: 'absolute',
+            top: 0,
+            right: 0,
+            bottom: 0,
+            left: 0,
+            backgroundColor: overlayColor,
+            opacity: overlayOpacity,
+          }}
+        />
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={dismissAccessibilityLabel}
+          accessibilityHint={dismissAccessibilityHint}
+          onPress={onClose}
+          style={{ position: 'absolute', top: 0, right: 0, bottom: 0, left: 0 }}
+        />
+        <Animated.View
+          style={{
+            maxHeight,
+            padding: themeTokens.spacing.screen,
+            paddingBottom: sheetPaddingBottom({
+              padBottomSafeArea,
+              paddingBottom,
+              insetBottom: insets.bottom,
+            }),
+            borderTopLeftRadius: themeTokens.radius.card,
+            borderTopRightRadius: themeTokens.radius.card,
+            borderCurve: 'continuous',
+            backgroundColor: colors.surface,
+            gap: themeTokens.spacing.section,
+            transform: [{ translateY: sheetTranslateY }],
+          }}
+        >
+          <View
+            style={{
+              flexDirection: 'row',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 12,
+            }}
+          >
+            <Text
+              selectable
+              style={{
+                color: colors.text,
+                fontSize: 20,
+                fontWeight: '700',
+                flex: 1,
+              }}
+            >
+              {title}
+            </Text>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={closeAccessibilityLabel}
+              accessibilityHint={closeAccessibilityHint}
+              onPress={onClose}
+              style={{
+                minHeight: themeTokens.minimumTouchTarget,
+                minWidth: themeTokens.minimumTouchTarget,
+                justifyContent: 'center',
+                alignItems: 'flex-end',
+              }}
+            >
+              <Text style={{ color: colors.primary, fontSize: 16, fontWeight: '600' }}>
+                Close
+              </Text>
+            </Pressable>
+          </View>
+          {children}
+        </Animated.View>
+      </View>
+    </Modal>
+  );
+}

--- a/mobile/src/components/logout-button.tsx
+++ b/mobile/src/components/logout-button.tsx
@@ -1,4 +1,4 @@
-import { Alert, Pressable, Text } from 'react-native';
+import { AccessibilityInfo, Alert, Pressable, Text } from 'react-native';
 
 import { ApiError } from '@/api/api-error';
 import { useAuth } from '@/auth/auth-context';
@@ -10,6 +10,8 @@ export function LogoutButton() {
   const { colors } = useTheme();
 
   async function handleLogout() {
+    AccessibilityInfo.announceForAccessibility('Signing out.');
+
     try {
       await logout();
     } catch (error) {
@@ -17,20 +19,25 @@ export function LogoutButton() {
         ? error.message
         : 'Logout could not be completed. Try again.';
       Alert.alert('Still signed in', message);
+      AccessibilityInfo.announceForAccessibility(message);
     }
   }
 
   return (
     <Pressable
       accessibilityRole="button"
-      accessibilityLabel="Log out"
+      accessibilityLabel="Sign out"
       accessibilityHint="Revokes this device session and returns to Login"
+      accessibilityState={{ disabled: isLoggingOut }}
       disabled={isLoggingOut}
       onPress={handleLogout}
-      style={{ minWidth: themeTokens.minimumTouchTarget, minHeight: themeTokens.minimumTouchTarget, justifyContent: 'center', paddingHorizontal: 12 }}
+      style={{
+        minHeight: themeTokens.minimumTouchTarget,
+        justifyContent: 'center',
+      }}
     >
-      <Text style={{ color: colors.primary, fontSize: 16, fontWeight: '600' }}>
-        {isLoggingOut ? 'Logging out…' : 'Log out'}
+      <Text style={{ color: colors.danger, fontSize: 16, fontWeight: '600' }}>
+        {isLoggingOut ? 'Signing out…' : 'Sign out'}
       </Text>
     </Pressable>
   );

--- a/mobile/src/components/tab-stack.tsx
+++ b/mobile/src/components/tab-stack.tsx
@@ -1,17 +1,17 @@
 import { Stack } from 'expo-router/stack';
 
-import { LogoutButton } from '@/components/logout-button';
+import { AccountMenu } from '@/components/account-menu';
 import { useTheme } from '@/theme/use-theme';
 
 type TabStackProps = {
   title: string;
 };
 
-function renderLogoutButton() {
-  return <LogoutButton />;
+function renderAccountButton() {
+  return <AccountMenu />;
 }
 
-export function TabStack({ title }: TabStackProps) {
+export function TabStack({ title }: Readonly<TabStackProps>) {
   const { colors } = useTheme();
 
   return (
@@ -23,7 +23,7 @@ export function TabStack({ title }: TabStackProps) {
         headerShadowVisible: false,
       }}
     >
-      <Stack.Screen name="index" options={{ title, headerRight: renderLogoutButton }} />
+      <Stack.Screen name="index" options={{ title, headerRight: renderAccountButton }} />
     </Stack>
   );
 }


### PR DESCRIPTION
## Problem

Authenticated mobile screens showed a persistent **Log out** text action and no way to see which Delight account is active. That is confusing after session restore and when more than one account exists. Sign out is an infrequent secondary action.

## Implementation

- Replace the header **Log out** control with a compact account button (initials, or a person glyph while identity is loading).
- Open a shared bottom sheet with the signed-in name and email, and place **Sign out** inside it.
- Reuse identity from `auth.user` after login, or from the existing bootstrap query after token restore. No backend or SecureStore identity persistence.
- Extract `BottomSheet` for the account surface and book picker (same slide-up chrome). Book picker uses zero chrome padding at the bottom so the list can sit closer to the gesture area; the account sheet still pads for Sign out.
- Preserve existing logout semantics: revoke the current token, keep the session on network/server failure, clear on 401.
- Document the reuse/extraction rule in `mobile/AGENTS.md`.

This may merge during DEL-281. It does not justify rebuilding the signed Dogfood APK.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm test` — 18 suites, 115 tests (account menu, bottom sheet, and existing log/session coverage)
- `npm run config:validate`
- `git diff --check`
- Manual Expo Go Android staging: identity after restore, dismiss, sign out, book-picker padding

## Linear

https://linear.app/orlando-dev/issue/DEL-286/show-active-account-identity-and-demote-sign-out-in-the-mobile-header

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an account menu with user initials, account details, accessible announcements, loading states, and sign-out support.
  * Added a reusable bottom sheet with animations, safe-area support, configurable sizing, accessible controls, and backdrop dismissal.
  * Updated book selection to use the new bottom-sheet presentation.

* **Accessibility**
  * Improved sign-out announcements, labels, disabled states, and touch-target sizing.

* **Tests**
  * Added coverage for account menus, bottom sheets, accessibility behavior, dismissal, errors, and safe-area layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->