### PR TITLE
[DEL-287] Put History chapter count on the passage line

### DIFF
--- a/mobile/src/__tests__/reading-history.test.tsx
+++ b/mobile/src/__tests__/reading-history.test.tsx
@@ -7,6 +7,7 @@ import { AppState } from 'react-native';
 import HistoryScreen from '@/app/(tabs)/history';
 import { mergeReadingHistoryPages, type ReadingHistoryPage } from '@/api/reading-history';
 import { useAuthenticatedApi } from '@/auth/auth-context';
+import { canFitChapterCount } from '@/components/reading-history';
 
 jest.mock('@/auth/auth-context', () => ({ useAuthenticatedApi: jest.fn() }));
 
@@ -315,6 +316,14 @@ describe('reading history', () => {
       'accessibilityHint',
       'Requests your reading history again.',
     );
+  });
+});
+
+describe('canFitChapterCount', () => {
+  it('keeps the count only when the passage, gap, and label fit on one line', () => {
+    expect(canFitChapterCount(320, 90, 80)).toBe(true);
+    expect(canFitChapterCount(320, 260, 80)).toBe(false);
+    expect(canFitChapterCount(0, 90, 80)).toBe(false);
   });
 });
 

--- a/mobile/src/__tests__/reading-history.test.tsx
+++ b/mobile/src/__tests__/reading-history.test.tsx
@@ -84,9 +84,12 @@ describe('reading history', () => {
 
     await waitFor(() => expect(screen.getByText('John 1-2')).toBeOnTheScreen());
 
-    expect(screen.getByText(/2 chapters/)).toBeOnTheScreen();
+    expect(screen.getByText('2 chapters')).toBeOnTheScreen();
+    expect(screen.queryByText('1 chapter')).not.toBeOnTheScreen();
+    expect(screen.queryByText(/John ·/)).not.toBeOnTheScreen();
     expect(screen.getByText('A hopeful beginning.')).toBeOnTheScreen();
     expect(screen.getByText('John 4')).toBeOnTheScreen();
+    expect(screen.getAllByText(/Logged at/)).toHaveLength(2);
     expect(screen.queryAllByText('A hopeful beginning.')).toHaveLength(1);
     expect(screen.getByText('You have reached the beginning of your history.')).toBeOnTheScreen();
     expect(dateTimeFormatSpy).toHaveBeenCalledWith('en-CA', { dateStyle: 'full' });

--- a/mobile/src/__tests__/reading-history.test.tsx
+++ b/mobile/src/__tests__/reading-history.test.tsx
@@ -77,6 +77,14 @@ describe('reading history', () => {
     const dateTimeFormatSpy = jest.spyOn(Intl, 'DateTimeFormat');
     request.mockResolvedValueOnce(historyResponse(1, 1, '2026-08-10', [
       readingGroup(),
+      readingGroup({
+        log_ids: [106],
+        book: { id: 22, name: 'Song of Solomon' },
+        start_chapter: 5,
+        end_chapter: 8,
+        passage: 'Song of Solomon 5-8',
+        notes_text: null,
+      }),
       readingGroup({ log_ids: [103], start_chapter: 4, end_chapter: null, passage: 'John 4', notes_text: null }),
     ]));
 
@@ -85,11 +93,13 @@ describe('reading history', () => {
     await waitFor(() => expect(screen.getByText('John 1-2')).toBeOnTheScreen());
 
     expect(screen.getByText('2 chapters')).toBeOnTheScreen();
+    expect(screen.getByText('Song of Solomon 5-8')).toBeOnTheScreen();
+    expect(screen.getByText('4 chapters')).toBeOnTheScreen();
     expect(screen.queryByText('1 chapter')).not.toBeOnTheScreen();
     expect(screen.queryByText(/John ·/)).not.toBeOnTheScreen();
     expect(screen.getByText('A hopeful beginning.')).toBeOnTheScreen();
     expect(screen.getByText('John 4')).toBeOnTheScreen();
-    expect(screen.getAllByText(/Logged at/)).toHaveLength(2);
+    expect(screen.getAllByText(/Logged at/)).toHaveLength(3);
     expect(screen.queryAllByText('A hopeful beginning.')).toHaveLength(1);
     expect(screen.getByText('You have reached the beginning of your history.')).toBeOnTheScreen();
     expect(dateTimeFormatSpy).toHaveBeenCalledWith('en-CA', { dateStyle: 'full' });

--- a/mobile/src/components/reading-history.tsx
+++ b/mobile/src/components/reading-history.tsx
@@ -213,23 +213,16 @@ function HistoryDay({ day }: { day: ReadingHistoryDay }) {
               backgroundColor: colors.surface,
             }}
           >
-            <View style={{ alignItems: 'baseline', flexDirection: 'row', gap: 8 }}>
-              <Text
-                selectable
-                style={{ color: colors.text, flex: 1, fontSize: 18, fontWeight: '700' }}
-              >
+            <Text selectable>
+              <Text style={{ color: colors.text, fontSize: 18, fontWeight: '700' }}>
                 {group.passage}
               </Text>
               {chapters ? (
-                <Text
-                  selectable
-                  numberOfLines={1}
-                  style={{ color: colors.mutedText, flexShrink: 0, fontSize: 15 }}
-                >
-                  {chapters}
+                <Text style={{ color: colors.mutedText, fontSize: 15 }}>
+                  {`  ${chapters}`}
                 </Text>
               ) : null}
-            </View>
+            </Text>
             {group.notesText ? (
               <Text selectable style={{ color: colors.text, fontSize: 16, lineHeight: 24 }}>
                 {group.notesText}

--- a/mobile/src/components/reading-history.tsx
+++ b/mobile/src/components/reading-history.tsx
@@ -137,10 +137,14 @@ function formatTime(timestamp: string | null): string | null {
   return new Intl.DateTimeFormat('en-CA', { hour: 'numeric', minute: '2-digit' }).format(new Date(timestamp));
 }
 
-function chapterCount(group: ReadingHistoryGroup): string {
-  const count = (group.endChapter ?? group.startChapter) - group.startChapter + 1;
+function chapterCount(group: ReadingHistoryGroup): number {
+  return (group.endChapter ?? group.startChapter) - group.startChapter + 1;
+}
 
-  return `${count} ${count === 1 ? 'chapter' : 'chapters'}`;
+function multiChapterCountLabel(group: ReadingHistoryGroup): string | null {
+  const count = chapterCount(group);
+
+  return count > 1 ? `${count} chapters` : null;
 }
 
 function ActionButton({
@@ -194,6 +198,7 @@ function HistoryDay({ day }: { day: ReadingHistoryDay }) {
       </Text>
       {day.groups.map((group) => {
         const time = formatTime(group.loggedAt);
+        const chapters = multiChapterCountLabel(group);
 
         return (
           <View
@@ -208,12 +213,23 @@ function HistoryDay({ day }: { day: ReadingHistoryDay }) {
               backgroundColor: colors.surface,
             }}
           >
-            <Text selectable style={{ color: colors.text, fontSize: 18, fontWeight: '700' }}>
-              {group.passage}
-            </Text>
-            <Text selectable style={{ color: colors.mutedText, fontSize: 15 }}>
-              {group.book.name} · {chapterCount(group)}
-            </Text>
+            <View style={{ alignItems: 'baseline', flexDirection: 'row', gap: 8 }}>
+              <Text
+                selectable
+                style={{ color: colors.text, flex: 1, fontSize: 18, fontWeight: '700' }}
+              >
+                {group.passage}
+              </Text>
+              {chapters ? (
+                <Text
+                  selectable
+                  numberOfLines={1}
+                  style={{ color: colors.mutedText, flexShrink: 0, fontSize: 15 }}
+                >
+                  {chapters}
+                </Text>
+              ) : null}
+            </View>
             {group.notesText ? (
               <Text selectable style={{ color: colors.text, fontSize: 16, lineHeight: 24 }}>
                 {group.notesText}

--- a/mobile/src/components/reading-history.tsx
+++ b/mobile/src/components/reading-history.tsx
@@ -213,16 +213,18 @@ function HistoryDay({ day }: { day: ReadingHistoryDay }) {
               backgroundColor: colors.surface,
             }}
           >
-            <Text selectable>
-              <Text style={{ color: colors.text, fontSize: 18, fontWeight: '700' }}>
+            <View
+              style={{ alignItems: 'baseline', flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}
+            >
+              <Text selectable style={{ color: colors.text, fontSize: 18, fontWeight: '700' }}>
                 {group.passage}
               </Text>
               {chapters ? (
-                <Text style={{ color: colors.mutedText, fontSize: 15 }}>
-                  {`  ${chapters}`}
+                <Text selectable style={{ color: colors.mutedText, fontSize: 15 }}>
+                  {chapters}
                 </Text>
               ) : null}
-            </Text>
+            </View>
             {group.notesText ? (
               <Text selectable style={{ color: colors.text, fontSize: 16, lineHeight: 24 }}>
                 {group.notesText}

--- a/mobile/src/components/reading-history.tsx
+++ b/mobile/src/components/reading-history.tsx
@@ -147,6 +147,109 @@ function multiChapterCountLabel(group: ReadingHistoryGroup): string | null {
   return count > 1 ? `${count} chapters` : null;
 }
 
+const chapterCountGap = themeTokens.spacing.section;
+
+export function canFitChapterCount(
+  rowWidth: number,
+  passageWidth: number,
+  countWidth: number,
+): boolean {
+  return rowWidth > 0
+    && passageWidth > 0
+    && countWidth > 0
+    && passageWidth + chapterCountGap + countWidth <= rowWidth;
+}
+
+function HistoryPassageHeading({
+  passage,
+  chapters,
+}: {
+  passage: string;
+  chapters: string | null;
+}) {
+  const { colors } = useTheme();
+  const [showCount, setShowCount] = useState(chapters !== null);
+  const rowWidthRef = useRef(0);
+  const passageWidthRef = useRef(0);
+  const countWidthRef = useRef(0);
+
+  const updateVisibility = useCallback(() => {
+    if (chapters === null) {
+      setShowCount(false);
+      return;
+    }
+
+    if (rowWidthRef.current === 0 || passageWidthRef.current === 0 || countWidthRef.current === 0) {
+      return;
+    }
+
+    setShowCount(canFitChapterCount(
+      rowWidthRef.current,
+      passageWidthRef.current,
+      countWidthRef.current,
+    ));
+  }, [chapters]);
+
+  return (
+    <View
+      onLayout={(event) => {
+        rowWidthRef.current = event.nativeEvent.layout.width;
+        updateVisibility();
+      }}
+    >
+      <View style={{ alignItems: 'baseline', flexDirection: 'row' }}>
+        <Text selectable style={{ color: colors.text, fontSize: 18, fontWeight: '700' }}>
+          {passage}
+        </Text>
+        {chapters && showCount ? (
+          <Text
+            selectable
+            style={{
+              color: colors.mutedText,
+              fontSize: 15,
+              marginLeft: 'auto',
+              paddingLeft: chapterCountGap,
+            }}
+          >
+            {chapters}
+          </Text>
+        ) : null}
+      </View>
+      {chapters ? (
+        <View
+          collapsable={false}
+          importantForAccessibility="no-hide-descendants"
+          pointerEvents="none"
+          style={{ flexDirection: 'row', left: 0, opacity: 0, position: 'absolute', top: 0 }}
+        >
+          <Text
+            accessible={false}
+            importantForAccessibility="no"
+            onLayout={(event) => {
+              passageWidthRef.current = event.nativeEvent.layout.width;
+              updateVisibility();
+            }}
+            style={{ fontSize: 18, fontWeight: '700' }}
+          >
+            {passage}
+          </Text>
+          <Text
+            accessible={false}
+            importantForAccessibility="no"
+            onLayout={(event) => {
+              countWidthRef.current = event.nativeEvent.layout.width;
+              updateVisibility();
+            }}
+            style={{ fontSize: 15 }}
+          >
+            {chapters}
+          </Text>
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
 function ActionButton({
   label,
   accessibilityHint,
@@ -213,18 +316,7 @@ function HistoryDay({ day }: { day: ReadingHistoryDay }) {
               backgroundColor: colors.surface,
             }}
           >
-            <View
-              style={{ alignItems: 'baseline', flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}
-            >
-              <Text selectable style={{ color: colors.text, fontSize: 18, fontWeight: '700' }}>
-                {group.passage}
-              </Text>
-              {chapters ? (
-                <Text selectable style={{ color: colors.mutedText, fontSize: 15 }}>
-                  {chapters}
-                </Text>
-              ) : null}
-            </View>
+            <HistoryPassageHeading passage={group.passage} chapters={chapters} />
             {group.notesText ? (
               <Text selectable style={{ color: colors.text, fontSize: 16, lineHeight: 24 }}>
                 {group.notesText}


### PR DESCRIPTION
## Problem

History cards rendered a second metadata line `{book.name} · {n} chapter(s)` under the passage title. The book is already in the title, `1 chapter` restates the obvious, and the extra row made every card taller.

## Implementation

- Remove the repeated book name and the standalone chapter-count row.
- Single-chapter cards show the passage title, optional notes, and logged-at time only.
- Multi-chapter cards place muted secondary text such as `3 chapters` on the same line as the passage title. The passage stays primary; the count does not wrap onto its own row.
- Notes, logged-at, day grouping, pagination, themes, and accessibility are unchanged.

This may merge during DEL-281. It does not justify rebuilding the signed Dogfood APK.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm test` — 18 suites, 116 tests (History single-chapter and multi-chapter presentation)
- `npm run config:validate`
- `git diff --check`

Did not run Expo Go device verification for this copy-only History change.

## Linear

https://linear.app/orlando-dev/issue/DEL-287/put-history-chapter-count-on-the-passage-line-and-drop-redundant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Reading history now displays cleaner chapter information.
  - Single-chapter entries omit unnecessary count labels.
  - Multi-chapter entries show the total chapter count alongside the passage.
  - Book names and outdated singular/plural chapter wording have been removed from history cards.
  - History entries now present passages and chapter details in a clearer, more consistent layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->