### PR TITLE
[DEL-289] Hide History Load more while older pages load

### DIFF
--- a/mobile/src/__tests__/reading-history.test.tsx
+++ b/mobile/src/__tests__/reading-history.test.tsx
@@ -8,6 +8,7 @@ import HistoryScreen from '@/app/(tabs)/history';
 import { mergeReadingHistoryPages, type ReadingHistoryPage } from '@/api/reading-history';
 import { useAuthenticatedApi } from '@/auth/auth-context';
 import { canFitChapterCount } from '@/components/reading-history';
+import { themeTokens } from '@/theme/tokens';
 
 jest.mock('@/auth/auth-context', () => ({ useAuthenticatedApi: jest.fn() }));
 
@@ -131,13 +132,67 @@ describe('reading history', () => {
 
     await user.press(loadMoreButton);
     await user.press(loadMoreButton);
+
+    await waitFor(() => expect(screen.getByLabelText('Loading more history')).toBeOnTheScreen());
+    expect(screen.queryByRole('button', { name: 'Load more' })).not.toBeOnTheScreen();
+
     resolveNextPage(pageTwo);
 
     await waitFor(() => expect(screen.getByText(/John 4/)).toBeOnTheScreen());
 
     expect(request).toHaveBeenCalledTimes(2);
     expect(screen.queryAllByText('John 1-2')).toHaveLength(1);
+    expect(screen.queryByRole('button', { name: 'Load more' })).not.toBeOnTheScreen();
+    expect(screen.queryByLabelText('Loading more history')).not.toBeOnTheScreen();
     expect(screen.getByText('You have reached the beginning of your history.')).toBeOnTheScreen();
+  });
+
+  it('keeps the pagination control height when swapping Load more for loading', async () => {
+    let resolveNextPage: (value: unknown) => void = () => undefined;
+    const nextPage = new Promise((resolve) => {
+      resolveNextPage = resolve;
+    });
+
+    request
+      .mockResolvedValueOnce(historyResponse(1, 2, '2026-08-10'))
+      .mockReturnValueOnce(nextPage);
+
+    const screen = await renderHistory();
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Load more' })).toBeOnTheScreen());
+
+    expect(screen.getByRole('button', { name: 'Load more' })).toHaveStyle({
+      minHeight: themeTokens.minimumTouchTarget,
+    });
+
+    const user = userEvent.setup();
+    await user.press(screen.getByRole('button', { name: 'Load more' }));
+
+    await waitFor(() => expect(screen.getByLabelText('Loading more history')).toBeOnTheScreen());
+    expect(screen.queryByRole('button', { name: 'Load more' })).not.toBeOnTheScreen();
+    expect(screen.getByLabelText('Loading more history')).toHaveStyle({
+      minHeight: themeTokens.minimumTouchTarget,
+    });
+
+    resolveNextPage(historyResponse(2, 2, '2026-08-09', [
+      readingGroup({ log_ids: [104], passage: 'John 4', date_read: '2026-08-09' }),
+    ]));
+
+    await waitFor(() => expect(screen.getByText('John 4')).toBeOnTheScreen());
+  });
+
+  it('restores Load more after a failed older-page request', async () => {
+    request
+      .mockResolvedValueOnce(historyResponse(1, 2, '2026-08-10'))
+      .mockRejectedValueOnce(new Error('Delight could not connect.'));
+
+    const screen = await renderHistory();
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Load more' })).toBeOnTheScreen());
+    const user = userEvent.setup();
+    await user.press(screen.getByRole('button', { name: 'Load more' }));
+
+    await waitFor(() => expect(screen.getByText('Delight could not connect.')).toBeOnTheScreen());
+    expect(screen.getByRole('button', { name: 'Load more' })).toBeOnTheScreen();
+    expect(screen.queryByLabelText('Loading more history')).not.toBeOnTheScreen();
   });
 
   it('refreshes instead of rendering a partial overlapping group', async () => {

--- a/mobile/src/components/reading-history.tsx
+++ b/mobile/src/components/reading-history.tsx
@@ -291,6 +291,42 @@ function ActionButton({
   );
 }
 
+function HistoryLoadMoreControl({
+  isLoadingMore,
+  onLoadMore,
+}: Readonly<{
+  isLoadingMore: boolean;
+  onLoadMore: () => void;
+}>) {
+  const { colors } = useTheme();
+
+  if (isLoadingMore) {
+    return (
+      <View
+        accessible
+        accessibilityLabel="Loading more history"
+        accessibilityLiveRegion="polite"
+        accessibilityRole="progressbar"
+        style={{
+          alignItems: 'center',
+          justifyContent: 'center',
+          minHeight: themeTokens.minimumTouchTarget,
+        }}
+      >
+        <ActivityIndicator color={colors.primary} />
+      </View>
+    );
+  }
+
+  return (
+    <ActionButton
+      label="Load more"
+      accessibilityHint="Loads older readings from your history."
+      onPress={onLoadMore}
+    />
+  );
+}
+
 function HistoryDay({ day }: { day: ReadingHistoryDay }) {
   const { colors } = useTheme();
 
@@ -404,13 +440,9 @@ export function ReadingHistory() {
               {history.loadMoreError ? (
                 <Text selectable style={{ color: colors.danger, fontSize: 16 }}>{history.loadMoreError.message}</Text>
               ) : null}
-              {history.isLoadingMore ? (
-                <ActivityIndicator accessibilityLabel="Loading more history" color={colors.primary} />
-              ) : null}
-              <ActionButton
-                label="Load more"
-                accessibilityHint="Loads older readings from your history."
-                onPress={() => void history.loadMore()}
+              <HistoryLoadMoreControl
+                isLoadingMore={history.isLoadingMore}
+                onLoadMore={() => void history.loadMore()}
               />
             </View>
           ) : (


### PR DESCRIPTION
## Problem

On mobile History, **Load more** and the loading spinner both rendered when an older page was in flight. The spinner sat above the button, which grew the footer and slid **Load more** behind the center Log tab.

## Implementation

- While older pages load, hide **Load more** and show one accessible loading indicator in that same footer slot.
- Both states use `themeTokens.minimumTouchTarget` so the list does not shift.
- Do not stack spinner + button.
- After success, the next page appears or end-of-history copy replaces the control.
- After failure, the error and **Load more** remain usable.

Mobile History only. No Home, Log, API, web History, EAS, or Dogfood APK rebuild from this PR. Linear is not marked Done.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm test` — 119 passed
- `npm run config:validate`
- `git diff --check`

No Expo Go device check was run for this footer swap.

## Linear

https://linear.app/orlando-dev/issue/DEL-289/hide-history-load-more-while-older-pages-are-loading

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reading history “Load more” experience by preventing duplicate requests.
  * Added clear loading feedback while older entries are being fetched.
  * Preserved the control’s touch target during loading.
  * Restored the “Load more” action and displayed an error when loading fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->