### PR TITLE
[DEL-290] Add Log today CTA to History

### DIFF
--- a/mobile/src/__tests__/reading-history.test.tsx
+++ b/mobile/src/__tests__/reading-history.test.tsx
@@ -12,7 +12,7 @@ import { themeTokens } from '@/theme/tokens';
 
 jest.mock('@/auth/auth-context', () => ({ useAuthenticatedApi: jest.fn() }));
 
-jest.mock('expo-router', () => ({ router: { push: jest.fn() } }));
+jest.mock('expo-router', () => ({ router: { navigate: jest.fn(), push: jest.fn() } }));
 
 jest.mock('react-native/Libraries/Components/RefreshControl/RefreshControl', () => {
   const { View } = jest.requireActual('react-native');
@@ -32,16 +32,38 @@ jest.spyOn(AppState, 'addEventListener').mockImplementation((_event, listener) =
   return { remove: jest.fn() };
 });
 
-async function renderHistory() {
+async function renderHistory(readToday: boolean | 'unavailable' = true) {
   const queryClient = new QueryClient({
-    defaultOptions: { queries: { gcTime: 0, retry: false }, mutations: { retry: false } },
+    defaultOptions: { queries: { gcTime: 0, retry: false, staleTime: Infinity }, mutations: { retry: false } },
   });
+
+  if (readToday !== 'unavailable') {
+    queryClient.setQueryData(['bootstrap'], bootstrapResponse(readToday).data);
+  }
 
   function Wrapper({ children }: PropsWithChildren) {
     return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
   }
 
-  return await render(<HistoryScreen />, { wrapper: Wrapper });
+  return Object.assign(await render(<HistoryScreen />, { wrapper: Wrapper }), { queryClient });
+}
+
+function bootstrapResponse(hasReadToday: boolean) {
+  return {
+    data: {
+      user: { id: 1, name: 'Reader', email: 'reader@example.com' },
+      today: '2026-08-10',
+      yesterday: '2026-08-09',
+      books: [],
+      recent_book_ids: [],
+      has_read_today: hasReadToday,
+      current_streak: 0,
+      longest_streak: 0,
+      this_week_days: 0,
+      this_month_days: 0,
+      activity: [],
+    },
+  };
 }
 
 function historyResponse(page: number, lastPage: number, date: string, groups = [readingGroup()]): unknown {
@@ -68,6 +90,7 @@ function readingGroup(overrides: Partial<Record<string, unknown>> = {}) {
 beforeEach(() => {
   request.mockReset();
   mockAppStateListener = undefined;
+  jest.mocked(router.navigate).mockClear();
   jest.mocked(router.push).mockClear();
   jest.mocked(useAuthenticatedApi).mockReturnValue(request);
 });
@@ -75,6 +98,57 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe('reading history', () => {
+  it('shows an accessible Log today callout when bootstrap reports no reading today', async () => {
+    request.mockResolvedValue(historyResponse(1, 1, '2026-08-09'));
+
+    const screen = await renderHistory(false);
+
+    expect(await screen.findByText('No reading logged today')).toBeOnTheScreen();
+    const logButton = screen.getByRole('button', { name: 'Log a reading' });
+    expect(logButton).toHaveProp('accessibilityHint', 'Opens the Log tab to record today’s reading.');
+    expect(logButton).toHaveStyle({ minHeight: themeTokens.minimumTouchTarget });
+    fireEvent.press(logButton);
+
+    expect(router.navigate).toHaveBeenCalledWith('/(tabs)/log');
+  });
+
+  it('hides the Log today callout when bootstrap reports a reading today', async () => {
+    request.mockResolvedValue(historyResponse(1, 1, '2026-08-10'));
+
+    const screen = await renderHistory(true);
+
+    await waitFor(() => expect(screen.getByText('John 1-2')).toBeOnTheScreen());
+    expect(screen.queryByText('No reading logged today')).not.toBeOnTheScreen();
+  });
+
+  it('hides the Log today callout after bootstrap refetch reports a reading today', async () => {
+    request.mockResolvedValue(historyResponse(1, 1, '2026-08-09'));
+
+    const screen = await renderHistory(false);
+    expect(await screen.findByText('No reading logged today')).toBeOnTheScreen();
+
+    await act(async () => {
+      screen.queryClient.setQueryData(['bootstrap'], bootstrapResponse(true).data);
+    });
+
+    await waitFor(() => expect(screen.queryByText('No reading logged today')).not.toBeOnTheScreen());
+  });
+
+  it('keeps History usable without a Log today claim when bootstrap is unavailable', async () => {
+    request.mockImplementation((path: string) => {
+      if (path === '/api/v1/bootstrap') {
+        return Promise.reject(new Error('Delight could not connect.'));
+      }
+
+      return Promise.resolve(historyResponse(1, 1, '2026-08-09'));
+    });
+
+    const screen = await renderHistory('unavailable');
+
+    expect(await screen.findByText('John 1-2')).toBeOnTheScreen();
+    expect(screen.queryByText('No reading logged today')).not.toBeOnTheScreen();
+  });
+
   it('renders API-ordered day groups and only renders notes when present', async () => {
     const dateTimeFormatSpy = jest.spyOn(Intl, 'DateTimeFormat');
     request.mockResolvedValueOnce(historyResponse(1, 1, '2026-08-10', [

--- a/mobile/src/components/reading-history.tsx
+++ b/mobile/src/components/reading-history.tsx
@@ -20,6 +20,7 @@ import {
   type ReadingHistoryGroup,
   type ReadingHistoryPage,
 } from '@/api/reading-history';
+import { fetchBootstrap } from '@/api/bootstrap';
 import { useAuthenticatedApi } from '@/auth/auth-context';
 import { themeTokens } from '@/theme/tokens';
 import { useTheme } from '@/theme/use-theme';
@@ -121,6 +122,15 @@ function useReadingHistory() {
     retryInitial: refetch,
     loadMore,
   };
+}
+
+function useReadTodayStatus() {
+  const request = useAuthenticatedApi();
+
+  return useQuery({
+    queryKey: ['bootstrap'],
+    queryFn: () => fetchBootstrap(request),
+  });
 }
 
 function formatDate(date: string): string {
@@ -327,6 +337,38 @@ function HistoryLoadMoreControl({
   );
 }
 
+function LogTodayCallout() {
+  const { colors } = useTheme();
+
+  return (
+    <View
+      accessibilityLiveRegion="polite"
+      style={{
+        gap: 8,
+        padding: themeTokens.spacing.section,
+        borderWidth: 1,
+        borderColor: colors.border,
+        borderRadius: themeTokens.radius.card,
+        borderCurve: 'continuous',
+        backgroundColor: colors.surface,
+      }}
+    >
+      <Text selectable style={{ color: colors.text, fontSize: 18, fontWeight: '700' }}>
+        No reading logged today
+      </Text>
+      <Text selectable style={{ color: colors.mutedText, fontSize: 16, lineHeight: 24 }}>
+        Start today’s reading whenever you’re ready.
+      </Text>
+      <ActionButton
+        label="Log a reading"
+        accessibilityHint="Opens the Log tab to record today’s reading."
+        onPress={() => router.navigate('/(tabs)/log')}
+        tone="accent"
+      />
+    </View>
+  );
+}
+
 function HistoryDay({ day }: { day: ReadingHistoryDay }) {
   const { colors } = useTheme();
 
@@ -373,6 +415,7 @@ function HistoryDay({ day }: { day: ReadingHistoryDay }) {
 export function ReadingHistory() {
   const { colors } = useTheme();
   const history = useReadingHistory();
+  const readTodayStatus = useReadTodayStatus();
 
   if (history.isInitialLoading) {
     return (
@@ -419,6 +462,7 @@ export function ReadingHistory() {
           History could not be refreshed. {history.refreshError.message}
         </Text>
       ) : null}
+      {readTodayStatus.data?.has_read_today === false ? <LogTodayCallout /> : null}
       {history.days.length === 0 ? (
         <View accessibilityLiveRegion="polite" style={{ gap: 16, paddingTop: 48 }}>
           <Text selectable style={{ color: colors.text, fontSize: 22, fontWeight: '700' }}>Your history is waiting</Text>


### PR DESCRIPTION
## Summary

History now shows a compact Log today callout when the server-authoritative Bootstrap response reports that no reading has been logged today.

## User impact

Before this change, a user with older History entries but no reading today had no contextual route from History into the existing logging flow. The new callout appears above History content, uses the existing Log tab, and disappears after Bootstrap updates to report a reading today.

## Root cause and fix

History fetched only paginated reading history, while the server-computed read-today state lives in the shared Bootstrap query. History now subscribes to that existing `['bootstrap']` TanStack Query cache. This preserves one shared source of server state, hides the callout when the state is unavailable, and reuses the Log flow instead of creating another form or submission path.

## Verification

- `npm ci --cache /tmp/delight-lock-review-npm-cache --no-audit --no-fund`
- `npm run lint`
- `npm run typecheck`
- `npm test` — 18 suites / 123 tests passed
- `npm run config:validate`
- `git diff --check`

Manual Android Expo Go validation remains pending: verify both read-today states, CTA navigation, post-log disappearance, light/dark modes, and enlarged font.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Log today” callout in Reading History when no reading has been logged for the current day.
  * Added navigation from the callout to the Log tab.
  * The callout updates automatically after reading status changes.

* **Bug Fixes**
  * Reading History remains usable when reading-status data is temporarily unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->