### PR TITLE
[DEL-291] Show streak-at-risk state on mobile Home

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ Local sections in this file are project-specific. The Boost-managed framework gu
 - **Flowbite**: Most complex components (Drawers, Modals, Dropdowns) are based on Flowbite. Refer to `resources/views/components/ui` for local wrappers.
 - **Responsiveness**: Always test mobile (mobile-first approach). Many users log readings on the go.
 - **Accessibility Priority**: Treat baseline accessibility as part of overall quality, including semantic HTML, alt text for meaningful imagery, keyboard navigation, and sufficient color contrast. In reviews, focus on high-impact, low-effort accessibility fixes and defer only low-impact enhancements that do not block core user flows.
+- **UI Review Findings**: Before dismissing an automated or human UI-review comment, verify it against the rendered state and relevant design tokens. Treat concrete, inexpensive usability issues as actionable even when the visual intent is sound.
 
 ## Coding Style & Naming Conventions
 - Structure services as `App\Services\{Domain}Service`; keep action classes verb-oriented.

--- a/app/Http/Controllers/Api/V1/MobileBootstrapController.php
+++ b/app/Http/Controllers/Api/V1/MobileBootstrapController.php
@@ -7,6 +7,7 @@ use App\Http\Resources\Api\V1\MobileBootstrapResource;
 use App\Models\User;
 use App\Services\BibleReferenceService;
 use App\Services\ReadingFormService;
+use App\Services\StreakStateService;
 use App\Services\UserStatisticsService;
 use Illuminate\Http\Request;
 
@@ -16,6 +17,7 @@ class MobileBootstrapController extends Controller
         Request $request,
         BibleReferenceService $bibleReferenceService,
         ReadingFormService $readingFormService,
+        StreakStateService $streakStateService,
         UserStatisticsService $userStatisticsService,
     ): MobileBootstrapResource {
         /** @var User $user */
@@ -23,6 +25,8 @@ class MobileBootstrapController extends Controller
         $today = today();
         $includeDeuterocanonical = $user->includesDeuterocanonicalBooks();
         $recentBooks = $readingFormService->getRecentBooksForForm($user);
+        $hasReadToday = $readingFormService->hasReadToday($user);
+        $streaks = $userStatisticsService->getStreakStatistics($user);
 
         return new MobileBootstrapResource([
             'user' => $user,
@@ -32,8 +36,12 @@ class MobileBootstrapController extends Controller
                 includeDeuterocanonical: $includeDeuterocanonical,
             ),
             'recent_book_ids' => array_column($recentBooks, 'id'),
-            'has_read_today' => $readingFormService->hasReadToday($user),
-            'streaks' => $userStatisticsService->getStreakStatistics($user),
+            'has_read_today' => $hasReadToday,
+            'streaks' => $streaks,
+            'streak_state' => $streakStateService->determineStreakState(
+                currentStreak: $streaks['current_streak'],
+                hasReadToday: $hasReadToday,
+            ),
             'reading_summary' => $userStatisticsService->getReadingSummary($user),
         ]);
     }

--- a/app/Http/Resources/Api/V1/MobileBootstrapResource.php
+++ b/app/Http/Resources/Api/V1/MobileBootstrapResource.php
@@ -24,6 +24,7 @@ class MobileBootstrapResource extends JsonResource
             'books' => $this->resource['books'],
             'recent_book_ids' => $this->resource['recent_book_ids'],
             'has_read_today' => $this->resource['has_read_today'],
+            'streak_state' => $this->resource['streak_state'],
             'current_streak' => $streaks['current_streak'],
             'longest_streak' => $streaks['longest_streak'],
             'this_week_days' => $readingSummary['this_week_days'],

--- a/mobile/src/__tests__/home-dashboard.test.tsx
+++ b/mobile/src/__tests__/home-dashboard.test.tsx
@@ -156,7 +156,7 @@ describe('native Home dashboard', () => {
     expect(screen.queryByText('Your streak is at risk')).not.toBeOnTheScreen();
   });
 
-  it('renders all supplied dashboard values without recalculating them', async () => {
+  it('renders streak and rhythm values while keeping general reading stats out of Home', async () => {
     mockRequest.mockResolvedValue(bootstrap({
       has_read_today: true,
       current_streak: 4,
@@ -175,8 +175,10 @@ describe('native Home dashboard', () => {
       borderWidth: 1,
       borderColor: '#cbd5e1',
     });
-    expect(screen.getByLabelText('Days read this week: 3')).toBeOnTheScreen();
-    expect(screen.getByLabelText('Days read this month: 8')).toBeOnTheScreen();
+    expect(screen.queryByText('Days read this week')).not.toBeOnTheScreen();
+    expect(screen.queryByText('Days read this month')).not.toBeOnTheScreen();
+    expect(screen.queryByText('This month')).not.toBeOnTheScreen();
+    expect(screen.queryByText('8 days')).not.toBeOnTheScreen();
     expect(screen.getByText('Best')).toBeOnTheScreen();
     expect(screen.getByLabelText('Current streak: 4 days. Best: 11 days.')).toHaveStyle({
       borderWidth: 1,

--- a/mobile/src/__tests__/home-dashboard.test.tsx
+++ b/mobile/src/__tests__/home-dashboard.test.tsx
@@ -126,6 +126,36 @@ describe('native Home dashboard', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/(tabs)/log');
   });
 
+  it('shows a restrained, accessible warning in the Today card when the server reports an at-risk streak', async () => {
+    mockRequest.mockResolvedValue(bootstrap({
+      current_streak: 3,
+      streak_state: 'warning',
+    }));
+
+    await renderHome();
+
+    expect(await screen.findByText('Your streak is at risk')).toBeOnTheScreen();
+    expect(screen.getByText('Log today’s reading before the day ends to keep your 3-day streak.')).toBeOnTheScreen();
+    expect(screen.getByText('Your streak is at risk').parent).toHaveStyle({
+      backgroundColor: '#fff7ed',
+      borderColor: '#f97316',
+    });
+    fireEvent.press(screen.getByRole('button', { name: 'Log today’s reading' }));
+    expect(mockNavigate).toHaveBeenCalledWith('/(tabs)/log');
+  });
+
+  it('keeps the generic Today card for an active streak before the warning threshold', async () => {
+    mockRequest.mockResolvedValue(bootstrap({
+      current_streak: 1,
+      streak_state: 'active',
+    }));
+
+    await renderHome();
+
+    expect(await screen.findByText('Ready when you are')).toBeOnTheScreen();
+    expect(screen.queryByText('Your streak is at risk')).not.toBeOnTheScreen();
+  });
+
   it('renders all supplied dashboard values without recalculating them', async () => {
     mockRequest.mockResolvedValue(bootstrap({
       has_read_today: true,

--- a/mobile/src/__tests__/home-dashboard.test.tsx
+++ b/mobile/src/__tests__/home-dashboard.test.tsx
@@ -140,6 +140,7 @@ describe('native Home dashboard', () => {
       backgroundColor: '#fff7ed',
       borderColor: '#f97316',
     });
+    expect(screen.getByText('Monday, August 10')).toHaveStyle({ color: '#0f172a' });
     fireEvent.press(screen.getByRole('button', { name: 'Log today’s reading' }));
     expect(mockNavigate).toHaveBeenCalledWith('/(tabs)/log');
   });

--- a/mobile/src/__tests__/theme-tokens.test.ts
+++ b/mobile/src/__tests__/theme-tokens.test.ts
@@ -17,6 +17,7 @@ describe('mobile semantic theme tokens', () => {
       primaryContrast: '#0f172a',
       accent: '#fb923c',
       accentContrast: '#0f172a',
+      accentSubtle: '#3f2a1d',
       accentAction: '#f97316',
       accentActionContrast: '#3b1a0a',
       success: '#86efac',

--- a/mobile/src/api/bootstrap.ts
+++ b/mobile/src/api/bootstrap.ts
@@ -40,8 +40,6 @@ export type HomeDashboardData = Pick<
   | 'streak_state'
   | 'current_streak'
   | 'longest_streak'
-  | 'this_week_days'
-  | 'this_month_days'
   | 'activity'
 >;
 

--- a/mobile/src/api/bootstrap.ts
+++ b/mobile/src/api/bootstrap.ts
@@ -21,6 +21,7 @@ export type BootstrapData = {
   books: BootstrapBook[];
   recent_book_ids: number[];
   has_read_today: boolean;
+  streak_state?: 'inactive' | 'active' | 'warning';
   current_streak: number;
   longest_streak: number;
   this_week_days: number;
@@ -36,6 +37,7 @@ export type HomeDashboardData = Pick<
   BootstrapData,
   | 'today'
   | 'has_read_today'
+  | 'streak_state'
   | 'current_streak'
   | 'longest_streak'
   | 'this_week_days'

--- a/mobile/src/components/home-dashboard.tsx
+++ b/mobile/src/components/home-dashboard.tsx
@@ -67,7 +67,7 @@ function getTodayCardContent({
     return {
       title: 'Your streak is at risk',
       description: `Log today’s reading before the day ends to keep your ${streakLabel}.`,
-      dateColor: colors.accent,
+      dateColor: warningTextColor,
       titleColor: warningTextColor,
       descriptionColor: warningTextColor,
       borderColor: colors.accent,

--- a/mobile/src/components/home-dashboard.tsx
+++ b/mobile/src/components/home-dashboard.tsx
@@ -175,7 +175,7 @@ function LoadingState() {
 }
 
 export function HomeDashboard() {
-  const { colors } = useTheme();
+  const { colors, mode } = useTheme();
   const request = useAuthenticatedApi();
   const router = useRouter();
   const { data, isPending, isRefetchError, isRefetching, refetch } = useQuery({
@@ -234,6 +234,9 @@ export function HomeDashboard() {
 
   const dashboard = data;
   const isEmpty = dashboard.activity.every((entry) => entry.count === 0);
+  const isStreakAtRisk = dashboard.streak_state === 'warning';
+  const warningTextColor = mode === 'dark' ? colors.text : colors.accentContrast;
+  const streakLabel = `${dashboard.current_streak}-day streak`;
 
   return (
     <ScrollView
@@ -255,22 +258,37 @@ export function HomeDashboard() {
           gap: 8,
           padding: themeTokens.spacing.screen,
           borderWidth: 1,
-          borderColor: colors.border,
+          borderColor: isStreakAtRisk ? colors.accent : colors.border,
           borderRadius: themeTokens.radius.card,
-          backgroundColor: colors.surface,
+          backgroundColor: isStreakAtRisk ? colors.accentSubtle : colors.surface,
         }}
       >
-        <Text selectable style={{ color: colors.mutedText, fontWeight: '600' }}>
+        <Text
+          selectable
+          style={{ color: isStreakAtRisk ? colors.accent : colors.mutedText, fontWeight: '600' }}
+        >
           {formatToday(dashboard.today)}
         </Text>
         <Text
           selectable
-          style={{ color: dashboard.has_read_today ? colors.success : colors.text, fontSize: 24, fontWeight: '700' }}
+          style={{
+            color: isStreakAtRisk ? warningTextColor : dashboard.has_read_today ? colors.success : colors.text,
+            fontSize: 24,
+            fontWeight: '700',
+          }}
         >
-          {dashboard.has_read_today ? 'Reading logged today' : 'Ready when you are'}
+          {dashboard.has_read_today
+            ? 'Reading logged today'
+            : isStreakAtRisk
+              ? 'Your streak is at risk'
+              : 'Ready when you are'}
         </Text>
-        <Text selectable style={{ color: colors.mutedText }}>
-          {dashboard.has_read_today ? 'Your reading is safely recorded.' : 'Log today’s reading to keep your journey moving.'}
+        <Text selectable style={{ color: isStreakAtRisk ? warningTextColor : colors.mutedText }}>
+          {dashboard.has_read_today
+            ? 'Your reading is safely recorded.'
+            : isStreakAtRisk
+              ? `Log today’s reading before the day ends to keep your ${streakLabel}.`
+              : 'Log today’s reading to keep your journey moving.'}
         </Text>
         {!dashboard.has_read_today ? (
           <Pressable

--- a/mobile/src/components/home-dashboard.tsx
+++ b/mobile/src/components/home-dashboard.tsx
@@ -68,26 +68,6 @@ function StreakCard({
   );
 }
 
-function SupportingStat({ label, value }: Readonly<{ label: string; value: number }>) {
-  const { colors } = useTheme();
-
-  return (
-    <View
-      accessible
-      accessibilityLabel={`${label}: ${value}`}
-      style={{ flex: 1, minWidth: 130, gap: 4, padding: themeTokens.spacing.section }}
-    >
-      <Text selectable style={{ color: colors.mutedText }}>{label}</Text>
-      <Text
-        selectable
-        style={{ color: colors.text, fontSize: 20, fontWeight: '700', fontVariant: ['tabular-nums'] }}
-      >
-        {value}
-      </Text>
-    </View>
-  );
-}
-
 function ActivityStrip({
   activity,
   today,
@@ -361,11 +341,10 @@ export function HomeDashboard() {
       ) : null}
 
       <View style={{ gap: 8 }}>
-        <StreakCard currentStreak={dashboard.current_streak} longestStreak={dashboard.longest_streak} />
-        <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: themeTokens.spacing.section }}>
-          <SupportingStat label="Days read this week" value={dashboard.this_week_days} />
-          <SupportingStat label="Days read this month" value={dashboard.this_month_days} />
-        </View>
+        <StreakCard
+          currentStreak={dashboard.current_streak}
+          longestStreak={dashboard.longest_streak}
+        />
       </View>
 
       <View style={{ gap: 8 }}>

--- a/mobile/src/components/home-dashboard.tsx
+++ b/mobile/src/components/home-dashboard.tsx
@@ -10,7 +10,7 @@ import {
 
 import { type HomeDashboardData } from '@/api/bootstrap';
 import { useBootstrap } from '@/hooks/use-bootstrap';
-import { themeTokens } from '@/theme/tokens';
+import { themeTokens, type ThemeColors } from '@/theme/tokens';
 import { useTheme } from '@/theme/use-theme';
 
 function formatDate(date: string, options: Intl.DateTimeFormatOptions): string {
@@ -21,6 +21,71 @@ function formatDate(date: string, options: Intl.DateTimeFormatOptions): string {
 
 function formatToday(date: string): string {
   return formatDate(date, { weekday: 'long', month: 'long', day: 'numeric' });
+}
+
+type TodayCardContent = {
+  title: string;
+  description: string;
+  dateColor: string;
+  titleColor: string;
+  descriptionColor: string;
+  borderColor: string;
+  backgroundColor: string;
+  showsLogAction: boolean;
+};
+
+function getTodayCardContent({
+  hasReadToday,
+  isStreakAtRisk,
+  currentStreak,
+  colors,
+  mode,
+}: Readonly<{
+  hasReadToday: boolean;
+  isStreakAtRisk: boolean;
+  currentStreak: number;
+  colors: ThemeColors;
+  mode: 'light' | 'dark';
+}>): TodayCardContent {
+  if (hasReadToday) {
+    return {
+      title: 'Reading logged today',
+      description: 'Your reading is safely recorded.',
+      dateColor: colors.mutedText,
+      titleColor: colors.success,
+      descriptionColor: colors.mutedText,
+      borderColor: colors.border,
+      backgroundColor: colors.surface,
+      showsLogAction: false,
+    };
+  }
+
+  if (isStreakAtRisk) {
+    const streakLabel = `${currentStreak}-day streak`;
+    const warningTextColor = mode === 'dark' ? colors.text : colors.accentContrast;
+
+    return {
+      title: 'Your streak is at risk',
+      description: `Log today’s reading before the day ends to keep your ${streakLabel}.`,
+      dateColor: colors.accent,
+      titleColor: warningTextColor,
+      descriptionColor: warningTextColor,
+      borderColor: colors.accent,
+      backgroundColor: colors.accentSubtle,
+      showsLogAction: true,
+    };
+  }
+
+  return {
+    title: 'Ready when you are',
+    description: 'Log today’s reading to keep your journey moving.',
+    dateColor: colors.mutedText,
+    titleColor: colors.text,
+    descriptionColor: colors.mutedText,
+    borderColor: colors.border,
+    backgroundColor: colors.surface,
+    showsLogAction: true,
+  };
 }
 
 function StreakCard({
@@ -192,9 +257,13 @@ export function HomeDashboard() {
 
   const dashboard = data;
   const isEmpty = dashboard.activity.every((entry) => entry.count === 0);
-  const isStreakAtRisk = dashboard.streak_state === 'warning';
-  const warningTextColor = mode === 'dark' ? colors.text : colors.accentContrast;
-  const streakLabel = `${dashboard.current_streak}-day streak`;
+  const todayCard = getTodayCardContent({
+    hasReadToday: dashboard.has_read_today,
+    isStreakAtRisk: dashboard.streak_state === 'warning',
+    currentStreak: dashboard.current_streak,
+    colors,
+    mode,
+  });
 
   return (
     <ScrollView
@@ -216,39 +285,31 @@ export function HomeDashboard() {
           gap: 8,
           padding: themeTokens.spacing.screen,
           borderWidth: 1,
-          borderColor: isStreakAtRisk ? colors.accent : colors.border,
+          borderColor: todayCard.borderColor,
           borderRadius: themeTokens.radius.card,
-          backgroundColor: isStreakAtRisk ? colors.accentSubtle : colors.surface,
+          backgroundColor: todayCard.backgroundColor,
         }}
       >
         <Text
           selectable
-          style={{ color: isStreakAtRisk ? colors.accent : colors.mutedText, fontWeight: '600' }}
+          style={{ color: todayCard.dateColor, fontWeight: '600' }}
         >
           {formatToday(dashboard.today)}
         </Text>
         <Text
           selectable
           style={{
-            color: isStreakAtRisk ? warningTextColor : dashboard.has_read_today ? colors.success : colors.text,
+            color: todayCard.titleColor,
             fontSize: 24,
             fontWeight: '700',
           }}
         >
-          {dashboard.has_read_today
-            ? 'Reading logged today'
-            : isStreakAtRisk
-              ? 'Your streak is at risk'
-              : 'Ready when you are'}
+          {todayCard.title}
         </Text>
-        <Text selectable style={{ color: isStreakAtRisk ? warningTextColor : colors.mutedText }}>
-          {dashboard.has_read_today
-            ? 'Your reading is safely recorded.'
-            : isStreakAtRisk
-              ? `Log today’s reading before the day ends to keep your ${streakLabel}.`
-              : 'Log today’s reading to keep your journey moving.'}
+        <Text selectable style={{ color: todayCard.descriptionColor }}>
+          {todayCard.description}
         </Text>
-        {!dashboard.has_read_today ? (
+        {todayCard.showsLogAction ? (
           <Pressable
             accessibilityRole="button"
             accessibilityLabel="Log today’s reading"

--- a/mobile/src/components/home-dashboard.tsx
+++ b/mobile/src/components/home-dashboard.tsx
@@ -1,9 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
 import { useRouter } from 'expo-router';
-import { useCallback, useEffect } from 'react';
 import {
-  AppState,
-  type AppStateStatus,
   ActivityIndicator,
   Pressable,
   RefreshControl,
@@ -12,8 +8,8 @@ import {
   View,
 } from 'react-native';
 
-import { fetchBootstrap, type HomeDashboardData } from '@/api/bootstrap';
-import { useAuthenticatedApi } from '@/auth/auth-context';
+import { type HomeDashboardData } from '@/api/bootstrap';
+import { useBootstrap } from '@/hooks/use-bootstrap';
 import { themeTokens } from '@/theme/tokens';
 import { useTheme } from '@/theme/use-theme';
 
@@ -156,26 +152,8 @@ function LoadingState() {
 
 export function HomeDashboard() {
   const { colors, mode } = useTheme();
-  const request = useAuthenticatedApi();
   const router = useRouter();
-  const { data, isPending, isRefetchError, isRefetching, refetch } = useQuery({
-    queryKey: ['bootstrap'],
-    queryFn: () => fetchBootstrap(request),
-  });
-
-  const refresh = useCallback(async () => {
-    await refetch();
-  }, [refetch]);
-
-  useEffect(() => {
-    function refreshWhenForegrounded(nextAppState: AppStateStatus) {
-      if (nextAppState === 'active') {
-        void refresh();
-      }
-    }
-
-    return AppState.addEventListener('change', refreshWhenForegrounded).remove;
-  }, [refresh]);
+  const { data, isPending, isRefetchError, isRefetching, refresh } = useBootstrap();
 
   if (isPending) {
     return <LoadingState />;

--- a/mobile/src/components/reading-log-form.tsx
+++ b/mobile/src/components/reading-log-form.tsx
@@ -1,12 +1,10 @@
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useRef, useState } from 'react';
 import { Controller, useForm, useWatch } from 'react-hook-form';
 import {
   AccessibilityInfo,
   ActivityIndicator,
-  AppState,
-  type AppStateStatus,
   KeyboardAvoidingView,
   Pressable,
   ScrollView,
@@ -16,11 +14,12 @@ import {
 } from 'react-native';
 
 import { ApiError } from '@/api/api-error';
-import { fetchBootstrap, type BootstrapBook, type BootstrapData } from '@/api/bootstrap';
+import { type BootstrapBook, type BootstrapData } from '@/api/bootstrap';
 import { createReadingLog, type CreateReadingInput, type CreatedReading } from '@/api/reading-log';
 import { useAuthenticatedApi } from '@/auth/auth-context';
 import { BookPickerModal } from '@/components/book-picker-modal';
 import { useKeyboardFocusedScroll } from '@/hooks/use-keyboard-focused-scroll';
+import { useBootstrap } from '@/hooks/use-bootstrap';
 import {
   chapterCountLabel,
   chaptersAfterBookChange,
@@ -623,25 +622,7 @@ function preferredInitialBookId(bootstrap: BootstrapData): number | null {
 
 export function ReadingLogForm() {
   const { colors } = useTheme();
-  const request = useAuthenticatedApi();
-  const { data, isPending, refetch } = useQuery({
-    queryKey: ['bootstrap'],
-    queryFn: () => fetchBootstrap(request),
-  });
-
-  const refresh = useCallback(async () => {
-    await refetch();
-  }, [refetch]);
-
-  useEffect(() => {
-    function refreshWhenForegrounded(nextAppState: AppStateStatus) {
-      if (nextAppState === 'active') {
-        void refresh();
-      }
-    }
-
-    return AppState.addEventListener('change', refreshWhenForegrounded).remove;
-  }, [refresh]);
+  const { data, isPending, refresh } = useBootstrap();
 
   if (isPending) {
     return <LoadingState />;

--- a/mobile/src/hooks/use-bootstrap.ts
+++ b/mobile/src/hooks/use-bootstrap.ts
@@ -1,0 +1,30 @@
+import { useQuery } from '@tanstack/react-query';
+import { useCallback, useEffect } from 'react';
+import { AppState, type AppStateStatus } from 'react-native';
+
+import { fetchBootstrap } from '@/api/bootstrap';
+import { useAuthenticatedApi } from '@/auth/auth-context';
+
+export function useBootstrap() {
+  const request = useAuthenticatedApi();
+  const { refetch, ...query } = useQuery({
+    queryKey: ['bootstrap'],
+    queryFn: () => fetchBootstrap(request),
+  });
+
+  const refresh = useCallback(async () => {
+    await refetch();
+  }, [refetch]);
+
+  useEffect(() => {
+    function refreshWhenForegrounded(nextAppState: AppStateStatus) {
+      if (nextAppState === 'active') {
+        void refresh();
+      }
+    }
+
+    return AppState.addEventListener('change', refreshWhenForegrounded).remove;
+  }, [refresh]);
+
+  return { ...query, refetch, refresh };
+}

--- a/mobile/src/theme/tokens.ts
+++ b/mobile/src/theme/tokens.ts
@@ -29,7 +29,7 @@ export const themeTokens = {
     primarySubtle: '#172554',
     accent: '#fb923c',
     accentContrast: '#0f172a',
-    accentSubtle: '#431407',
+    accentSubtle: '#3f2a1d',
     accentAction: '#f97316',
     accentActionContrast: '#3b1a0a',
     success: '#86efac',

--- a/mobile/src/theme/tokens.ts
+++ b/mobile/src/theme/tokens.ts
@@ -50,4 +50,5 @@ export const themeTokens = {
   minimumTouchTarget: 44,
 } as const;
 
-export type ThemeColors = (typeof themeTokens)['light'];
+export type ThemeColors = (typeof themeTokens)['light'] | (typeof themeTokens)['dark'];
+export type ThemeMode = 'light' | 'dark';

--- a/mobile/src/theme/use-theme.ts
+++ b/mobile/src/theme/use-theme.ts
@@ -1,10 +1,10 @@
 import { useColorScheme } from 'react-native';
 
-import { themeTokens } from '@/theme/tokens';
+import { themeTokens, type ThemeMode } from '@/theme/tokens';
 
 export function useTheme() {
   const colorScheme = useColorScheme();
-  const mode = colorScheme === 'dark' ? 'dark' : 'light';
+  const mode: ThemeMode = colorScheme === 'dark' ? 'dark' : 'light';
 
   return {
     colors: themeTokens[mode],

--- a/tests/Feature/Api/V1/MobileBootstrapTest.php
+++ b/tests/Feature/Api/V1/MobileBootstrapTest.php
@@ -9,6 +9,8 @@ const MOBILE_BOOTSTRAP_ENDPOINT = '/api/v1/bootstrap';
 const MOBILE_BOOTSTRAP_TODAY = '2026-08-09';
 const MOBILE_BOOTSTRAP_YESTERDAY = '2026-08-08';
 const MOBILE_BOOTSTRAP_TWO_DAYS_AGO = '2026-08-07';
+const MOBILE_BOOTSTRAP_MORNING = ' 08:00:00';
+const MOBILE_BOOTSTRAP_MIDDAY = ' 12:00:00';
 
 beforeEach(function (): void {
     Cache::flush();
@@ -111,10 +113,10 @@ it('returns canon-aware books and filters recent books before limiting', functio
     $user = User::factory()->create();
 
     createBootstrapReading($user, 67, MOBILE_BOOTSTRAP_TODAY, MOBILE_BOOTSTRAP_TODAY.' 00:20:00');
-    createBootstrapReading($user, 1, MOBILE_BOOTSTRAP_YESTERDAY, MOBILE_BOOTSTRAP_YESTERDAY.' 12:00:00');
-    createBootstrapReading($user, 40, MOBILE_BOOTSTRAP_TWO_DAYS_AGO, MOBILE_BOOTSTRAP_TWO_DAYS_AGO.' 12:00:00');
-    createBootstrapReading($user, 43, '2026-08-06', '2026-08-06 12:00:00');
-    createBootstrapReading($user, 19, '2026-08-05', '2026-08-05 12:00:00');
+    createBootstrapReading($user, 1, MOBILE_BOOTSTRAP_YESTERDAY, MOBILE_BOOTSTRAP_YESTERDAY.MOBILE_BOOTSTRAP_MIDDAY);
+    createBootstrapReading($user, 40, MOBILE_BOOTSTRAP_TWO_DAYS_AGO, MOBILE_BOOTSTRAP_TWO_DAYS_AGO.MOBILE_BOOTSTRAP_MIDDAY);
+    createBootstrapReading($user, 43, '2026-08-06', '2026-08-06'.MOBILE_BOOTSTRAP_MIDDAY);
+    createBootstrapReading($user, 19, '2026-08-05', '2026-08-05'.MOBILE_BOOTSTRAP_MIDDAY);
 
     $standardResponse = $this->withToken($user->createToken('Pixel', ['mobile'])->plainTextToken)
         ->getJson(MOBILE_BOOTSTRAP_ENDPOINT)
@@ -142,8 +144,8 @@ it('returns canon-aware books and filters recent books before limiting', functio
 it('returns the existing statistics and fourteen-day activity counts', function (): void {
     $user = User::factory()->create();
 
-    createBootstrapReading($user, 1, MOBILE_BOOTSTRAP_TWO_DAYS_AGO, MOBILE_BOOTSTRAP_TWO_DAYS_AGO.' 08:00:00');
-    createBootstrapReading($user, 1, MOBILE_BOOTSTRAP_YESTERDAY, MOBILE_BOOTSTRAP_YESTERDAY.' 08:00:00', 2);
+    createBootstrapReading($user, 1, MOBILE_BOOTSTRAP_TWO_DAYS_AGO, MOBILE_BOOTSTRAP_TWO_DAYS_AGO.MOBILE_BOOTSTRAP_MORNING);
+    createBootstrapReading($user, 1, MOBILE_BOOTSTRAP_YESTERDAY, MOBILE_BOOTSTRAP_YESTERDAY.MOBILE_BOOTSTRAP_MORNING, 2);
     createBootstrapReading($user, 1, MOBILE_BOOTSTRAP_TODAY, MOBILE_BOOTSTRAP_TODAY.' 00:10:00', 3);
     createBootstrapReading($user, 40, MOBILE_BOOTSTRAP_TODAY, MOBILE_BOOTSTRAP_TODAY.' 00:20:00');
 
@@ -165,40 +167,32 @@ it('returns the existing statistics and fourteen-day activity counts', function 
         ->and(Cache::has("user_total_reading_days_{$user->id}"))->toBeTrue();
 });
 
-it('returns the server-computed warning state only for an unread active streak after 18:00', function (): void {
-    Carbon::setTestNow(Carbon::parse(MOBILE_BOOTSTRAP_TODAY.' 18:00:00', config('app.timezone')));
+it('returns the server-computed state for an unread active streak at the warning threshold', function (
+    string $time,
+    string $expectedState,
+): void {
+    Carbon::setTestNow(Carbon::parse(MOBILE_BOOTSTRAP_TODAY." {$time}", config('app.timezone')));
 
     $user = User::factory()->create();
-    createBootstrapReading($user, 1, MOBILE_BOOTSTRAP_YESTERDAY, MOBILE_BOOTSTRAP_YESTERDAY.' 08:00:00');
+    createBootstrapReading($user, 1, MOBILE_BOOTSTRAP_YESTERDAY, MOBILE_BOOTSTRAP_YESTERDAY.MOBILE_BOOTSTRAP_MORNING);
 
     $this->withToken($user->createToken('Pixel', ['mobile'])->plainTextToken)
         ->getJson(MOBILE_BOOTSTRAP_ENDPOINT)
         ->assertSuccessful()
         ->assertJsonPath('data.has_read_today', false)
         ->assertJsonPath('data.current_streak', 1)
-        ->assertJsonPath('data.streak_state', 'warning');
-});
-
-it('returns active instead of warning before 18:00 for an unread active streak', function (): void {
-    Carbon::setTestNow(Carbon::parse(MOBILE_BOOTSTRAP_TODAY.' 17:59:00', config('app.timezone')));
-
-    $user = User::factory()->create();
-    createBootstrapReading($user, 1, MOBILE_BOOTSTRAP_YESTERDAY, MOBILE_BOOTSTRAP_YESTERDAY.' 08:00:00');
-
-    $this->withToken($user->createToken('Pixel', ['mobile'])->plainTextToken)
-        ->getJson(MOBILE_BOOTSTRAP_ENDPOINT)
-        ->assertSuccessful()
-        ->assertJsonPath('data.has_read_today', false)
-        ->assertJsonPath('data.current_streak', 1)
-        ->assertJsonPath('data.streak_state', 'active');
-});
+        ->assertJsonPath('data.streak_state', $expectedState);
+})->with([
+    'at 18:00' => ['18:00:00', 'warning'],
+    'before 18:00' => ['17:59:00', 'active'],
+]);
 
 it('does not return warning after today has been read', function (): void {
     Carbon::setTestNow(Carbon::parse(MOBILE_BOOTSTRAP_TODAY.' 18:00:00', config('app.timezone')));
 
     $user = User::factory()->create();
-    createBootstrapReading($user, 1, MOBILE_BOOTSTRAP_YESTERDAY, MOBILE_BOOTSTRAP_YESTERDAY.' 08:00:00');
-    createBootstrapReading($user, 1, MOBILE_BOOTSTRAP_TODAY, MOBILE_BOOTSTRAP_TODAY.' 12:00:00');
+    createBootstrapReading($user, 1, MOBILE_BOOTSTRAP_YESTERDAY, MOBILE_BOOTSTRAP_YESTERDAY.MOBILE_BOOTSTRAP_MORNING);
+    createBootstrapReading($user, 1, MOBILE_BOOTSTRAP_TODAY, MOBILE_BOOTSTRAP_TODAY.MOBILE_BOOTSTRAP_MIDDAY);
 
     $this->withToken($user->createToken('Pixel', ['mobile'])->plainTextToken)
         ->getJson(MOBILE_BOOTSTRAP_ENDPOINT)

--- a/tests/Feature/Api/V1/MobileBootstrapTest.php
+++ b/tests/Feature/Api/V1/MobileBootstrapTest.php
@@ -45,6 +45,7 @@ it('returns complete zero-filled bootstrap data in the application timezone', fu
         ->assertJsonPath('data.yesterday', MOBILE_BOOTSTRAP_YESTERDAY)
         ->assertJsonPath('data.recent_book_ids', [])
         ->assertJsonPath('data.has_read_today', false)
+        ->assertJsonPath('data.streak_state', 'inactive')
         ->assertJsonPath('data.current_streak', 0)
         ->assertJsonPath('data.longest_streak', 0)
         ->assertJsonPath('data.this_week_days', 0)
@@ -59,6 +60,7 @@ it('returns complete zero-filled bootstrap data in the application timezone', fu
                 'books' => ['*' => ['id', 'name', 'chapters', 'testament']],
                 'recent_book_ids',
                 'has_read_today',
+                'streak_state',
                 'current_streak',
                 'longest_streak',
                 'this_week_days',
@@ -149,6 +151,7 @@ it('returns the existing statistics and fourteen-day activity counts', function 
         ->getJson(MOBILE_BOOTSTRAP_ENDPOINT)
         ->assertSuccessful()
         ->assertJsonPath('data.has_read_today', true)
+        ->assertJsonPath('data.streak_state', 'active')
         ->assertJsonPath('data.current_streak', 3)
         ->assertJsonPath('data.longest_streak', 3)
         ->assertJsonPath('data.this_week_days', 1)
@@ -160,6 +163,49 @@ it('returns the existing statistics and fourteen-day activity counts', function 
     expect(Cache::has("user_current_streak_{$user->id}"))->toBeTrue()
         ->and(Cache::has("user_recent_reading_activity_series_{$user->id}"))->toBeTrue()
         ->and(Cache::has("user_total_reading_days_{$user->id}"))->toBeTrue();
+});
+
+it('returns the server-computed warning state only for an unread active streak after 18:00', function (): void {
+    Carbon::setTestNow(Carbon::parse(MOBILE_BOOTSTRAP_TODAY.' 18:00:00', config('app.timezone')));
+
+    $user = User::factory()->create();
+    createBootstrapReading($user, 1, MOBILE_BOOTSTRAP_YESTERDAY, MOBILE_BOOTSTRAP_YESTERDAY.' 08:00:00');
+
+    $this->withToken($user->createToken('Pixel', ['mobile'])->plainTextToken)
+        ->getJson(MOBILE_BOOTSTRAP_ENDPOINT)
+        ->assertSuccessful()
+        ->assertJsonPath('data.has_read_today', false)
+        ->assertJsonPath('data.current_streak', 1)
+        ->assertJsonPath('data.streak_state', 'warning');
+});
+
+it('returns active instead of warning before 18:00 for an unread active streak', function (): void {
+    Carbon::setTestNow(Carbon::parse(MOBILE_BOOTSTRAP_TODAY.' 17:59:00', config('app.timezone')));
+
+    $user = User::factory()->create();
+    createBootstrapReading($user, 1, MOBILE_BOOTSTRAP_YESTERDAY, MOBILE_BOOTSTRAP_YESTERDAY.' 08:00:00');
+
+    $this->withToken($user->createToken('Pixel', ['mobile'])->plainTextToken)
+        ->getJson(MOBILE_BOOTSTRAP_ENDPOINT)
+        ->assertSuccessful()
+        ->assertJsonPath('data.has_read_today', false)
+        ->assertJsonPath('data.current_streak', 1)
+        ->assertJsonPath('data.streak_state', 'active');
+});
+
+it('does not return warning after today has been read', function (): void {
+    Carbon::setTestNow(Carbon::parse(MOBILE_BOOTSTRAP_TODAY.' 18:00:00', config('app.timezone')));
+
+    $user = User::factory()->create();
+    createBootstrapReading($user, 1, MOBILE_BOOTSTRAP_YESTERDAY, MOBILE_BOOTSTRAP_YESTERDAY.' 08:00:00');
+    createBootstrapReading($user, 1, MOBILE_BOOTSTRAP_TODAY, MOBILE_BOOTSTRAP_TODAY.' 12:00:00');
+
+    $this->withToken($user->createToken('Pixel', ['mobile'])->plainTextToken)
+        ->getJson(MOBILE_BOOTSTRAP_ENDPOINT)
+        ->assertSuccessful()
+        ->assertJsonPath('data.has_read_today', true)
+        ->assertJsonPath('data.current_streak', 2)
+        ->assertJsonPath('data.streak_state', 'active');
 });
 
 it('does not serve previous-day statistics after midnight', function (): void {


### PR DESCRIPTION
## Problem

Native Home did not distinguish an active streak with no reading logged after the server's 18:00 warning threshold.

## Implementation

- Adds server-computed `streak_state` to the versioned mobile bootstrap response, reusing the existing streak-state service.
- Renders a restrained at-risk Today card in Expo Home while preserving generic and completed states.
- Keeps older clients compatible by retaining existing bootstrap fields.
- Removes Home’s weekly/monthly count presentation so the hierarchy is Today status, streak, then the 14-day rhythm.
- Softens the dark warning surface without changing the light treatment.

## Verification

- Focused Laravel mobile bootstrap Pest coverage for inactive, active, warning, and read-today states.
- Mobile focused Jest: Home dashboard and theme tokens.
- Mobile full Jest: 18 suites, 127 tests passing.
- `npm run lint`
- `npm run typecheck`
- `npm run config:validate` (local Expo config resolves the dev API URL)
- `git diff --check`

## Manual review

Use Expo Go against the dev API. With an active streak, no reading today, and server time after 18:00, Home should show “Your streak is at risk”; logging a reading should return the completed Today state.

No EAS build, production/staging deployment, or signing change is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added streak status information to the mobile dashboard.
  * Added an at-risk warning when today’s reading is incomplete near the daily cutoff.
  * Improved dashboard cards with status-based messaging and theme-aware styling.
  * Added automatic data refresh when the app becomes active.

* **Bug Fixes**
  * Removed outdated weekly and monthly reading statistics from the Home dashboard.
  * Updated dark-theme accent styling for improved visual consistency.

* **Tests**
  * Added coverage for inactive, active, and warning streak states and dashboard behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->