### PR TITLE
[DEL-293] Show stored profile photos in the mobile account menu

### DIFF
--- a/app/Http/Resources/Api/V1/MobileUserResource.php
+++ b/app/Http/Resources/Api/V1/MobileUserResource.php
@@ -18,6 +18,7 @@ class MobileUserResource extends JsonResource
             'id' => $this->resource->id,
             'name' => $this->resource->name,
             'email' => $this->resource->email,
+            'avatar_url' => $this->resource->avatar_url,
         ];
     }
 }

--- a/mobile/src/__tests__/account-menu.test.tsx
+++ b/mobile/src/__tests__/account-menu.test.tsx
@@ -105,6 +105,11 @@ describe('account menu', () => {
       'Shows the signed-in account and sign out',
     );
     expect(screen.getByText('R')).toBeOnTheScreen();
+    expect(screen.getByTestId('header-account-avatar')).toHaveStyle({
+      width: 32,
+      height: 32,
+      borderRadius: 16,
+    });
     expect(screen.queryByLabelText('Sign out')).not.toBeOnTheScreen();
     expect(screen.queryByText('Log out')).not.toBeOnTheScreen();
     expect(request).not.toHaveBeenCalled();

--- a/mobile/src/__tests__/account-menu.test.tsx
+++ b/mobile/src/__tests__/account-menu.test.tsx
@@ -6,7 +6,7 @@ import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import { ApiError } from '@/api/api-error';
 import { AccountMenu, accountInitials } from '@/components/account-menu';
-import { useAuth, useAuthenticatedApi } from '@/auth/auth-context';
+import { useAuth, useAuthenticatedApi, type AuthUser } from '@/auth/auth-context';
 
 jest.mock('@/auth/auth-context', () => ({
   useAuth: jest.fn(),
@@ -17,7 +17,7 @@ const request = jest.fn();
 const logout = jest.fn();
 let queryClient: QueryClient;
 
-const sessionUser = { id: 1, name: 'Reader', email: 'reader@example.com' };
+const sessionUser: AuthUser = { id: 1, name: 'Reader', email: 'reader@example.com' };
 
 function bootstrap(overrides: Record<string, unknown> = {}) {
   return {
@@ -121,6 +121,32 @@ describe('account menu', () => {
     expect(AccessibilityInfo.announceForAccessibility).toHaveBeenCalledWith(
       'Signed in as Reader, reader@example.com.',
     );
+  });
+
+  it('shows the stored profile photo in the account control and sheet', async () => {
+    mockAuth({ ...sessionUser, avatar_url: 'https://example.com/reader.jpg' });
+    await renderMenu();
+
+    const headerImage = screen.getByTestId('account-avatar-image');
+    expect(headerImage).toHaveProp('source', { uri: 'https://example.com/reader.jpg' });
+    expect(headerImage).toHaveStyle({ opacity: 0 });
+
+    await fireEvent(headerImage, 'load');
+    expect(headerImage).toHaveStyle({ opacity: 1 });
+
+    await fireEvent.press(screen.getByLabelText('Account for Reader'));
+    expect(screen.getByTestId('account-avatar-image')).toHaveStyle({ width: 56, height: 56 });
+  });
+
+  it('keeps initials visible while the photo loads and after it fails', async () => {
+    mockAuth({ ...sessionUser, avatar_url: 'not-a-valid-image-url' });
+    await renderMenu();
+
+    expect(screen.getByText('R')).toBeOnTheScreen();
+    await fireEvent(screen.getByTestId('account-avatar-image'), 'error');
+
+    expect(screen.getByText('R')).toBeOnTheScreen();
+    expect(screen.queryByTestId('account-avatar-image')).not.toBeOnTheScreen();
   });
 
   it('reads restored identity from bootstrap when the session has no user', async () => {

--- a/mobile/src/api/bootstrap.ts
+++ b/mobile/src/api/bootstrap.ts
@@ -15,6 +15,7 @@ export type BootstrapData = {
     id: number;
     name: string;
     email: string;
+    avatar_url?: string | null;
   };
   today: string;
   yesterday: string;

--- a/mobile/src/auth/auth-context.tsx
+++ b/mobile/src/auth/auth-context.tsx
@@ -9,6 +9,7 @@ export type AuthUser = {
   id: number;
   name: string;
   email: string;
+  avatar_url?: string | null;
 };
 
 type TokenResponse = {

--- a/mobile/src/components/account-menu.tsx
+++ b/mobile/src/components/account-menu.tsx
@@ -1,7 +1,7 @@
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { useQuery } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
-import { AccessibilityInfo, Pressable, Text, View } from 'react-native';
+import { AccessibilityInfo, Image, Pressable, Text, View } from 'react-native';
 
 import { fetchBootstrap } from '@/api/bootstrap';
 import { useAuth, useAuthenticatedApi, type AuthUser } from '@/auth/auth-context';
@@ -56,6 +56,69 @@ function identityAnnouncement(user: AuthUser | null, isLoading: boolean): string
   return 'Account details are unavailable.';
 }
 
+type AccountAvatarProps = {
+  color: string;
+  initials: string | null;
+  url?: string | null;
+  size: number;
+};
+
+function AccountAvatar({ color, initials, url, size }: AccountAvatarProps) {
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [hasFailed, setHasFailed] = useState(false);
+
+  const borderRadius = size / 2;
+
+  return (
+    <View
+      accessible={false}
+      style={{
+        width: size,
+        height: size,
+        alignItems: 'center',
+        justifyContent: 'center',
+        borderRadius,
+        overflow: 'hidden',
+      }}
+    >
+      {initials ? (
+        <Text
+          accessible={false}
+          adjustsFontSizeToFit
+          minimumFontScale={0.7}
+          numberOfLines={1}
+          style={{ color, fontSize: size * 0.4, fontWeight: '700' }}
+        >
+          {initials}
+        </Text>
+      ) : (
+        <MaterialCommunityIcons
+          accessible={false}
+          color={color}
+          name="account"
+          size={size * 0.625}
+        />
+      )}
+      {url && !hasFailed ? (
+        <Image
+          accessible={false}
+          testID="account-avatar-image"
+          source={{ uri: url }}
+          resizeMode="cover"
+          onLoad={() => setIsLoaded(true)}
+          onError={() => setHasFailed(true)}
+          style={{
+            position: 'absolute',
+            width: size,
+            height: size,
+            opacity: isLoaded ? 1 : 0,
+          }}
+        />
+      ) : null}
+    </View>
+  );
+}
+
 export function AccountMenu() {
   const { user: sessionUser } = useAuth();
   const request = useAuthenticatedApi();
@@ -108,30 +171,16 @@ export function AccountMenu() {
             paddingHorizontal: 6,
             borderRadius: 16,
             backgroundColor: colors.primarySubtle,
+            overflow: 'hidden',
           }}
         >
-          {initials ? (
-            <Text
-              accessible={false}
-              adjustsFontSizeToFit
-              minimumFontScale={0.7}
-              numberOfLines={1}
-              style={{
-                color: colors.primary,
-                fontSize: 13,
-                fontWeight: '700',
-              }}
-            >
-              {initials}
-            </Text>
-          ) : (
-            <MaterialCommunityIcons
-              accessible={false}
-              color={colors.primary}
-              name="account"
-              size={20}
-            />
-          )}
+          <AccountAvatar
+            key={user?.avatar_url ?? 'fallback'}
+            color={colors.primary}
+            initials={initials}
+            url={user?.avatar_url}
+            size={32}
+          />
         </View>
       </Pressable>
       <BottomSheet
@@ -147,6 +196,24 @@ export function AccountMenu() {
         <View accessibilityLiveRegion="polite" style={{ gap: 4 }}>
           {user ? (
             <>
+              <View
+                style={{
+                  width: 56,
+                  height: 56,
+                  borderRadius: 28,
+                  backgroundColor: colors.primarySubtle,
+                  overflow: 'hidden',
+                  marginBottom: 8,
+                }}
+              >
+                <AccountAvatar
+                  key={user.avatar_url ?? 'fallback'}
+                  color={colors.primary}
+                  initials={initials}
+                  url={user.avatar_url}
+                  size={56}
+                />
+              </View>
               <Text
                 selectable
                 style={{ color: colors.text, fontSize: 18, fontWeight: '700' }}

--- a/mobile/src/components/account-menu.tsx
+++ b/mobile/src/components/account-menu.tsx
@@ -162,13 +162,13 @@ export function AccountMenu() {
         }}
       >
         <View
+          testID="header-account-avatar"
           accessible={false}
           style={{
-            minWidth: 32,
-            minHeight: 32,
+            width: 32,
+            height: 32,
             alignItems: 'center',
             justifyContent: 'center',
-            paddingHorizontal: 6,
             borderRadius: 16,
             backgroundColor: colors.primarySubtle,
             overflow: 'hidden',

--- a/tests/Feature/Api/V1/MobileBootstrapTest.php
+++ b/tests/Feature/Api/V1/MobileBootstrapTest.php
@@ -34,7 +34,9 @@ it('requires a Sanctum token with the mobile ability', function (): void {
 });
 
 it('returns complete zero-filled bootstrap data in the application timezone', function (): void {
-    $user = User::factory()->create();
+    $user = User::factory()->create([
+        'avatar_url' => 'https://example.com/reader.jpg',
+    ]);
     $token = $user->createToken('Pixel', ['mobile'])->plainTextToken;
 
     $response = $this->withToken($token)
@@ -43,6 +45,7 @@ it('returns complete zero-filled bootstrap data in the application timezone', fu
         ->assertJsonPath('data.user.id', $user->id)
         ->assertJsonPath('data.user.name', $user->name)
         ->assertJsonPath('data.user.email', $user->email)
+        ->assertJsonPath('data.user.avatar_url', 'https://example.com/reader.jpg')
         ->assertJsonPath('data.today', MOBILE_BOOTSTRAP_TODAY)
         ->assertJsonPath('data.yesterday', MOBILE_BOOTSTRAP_YESTERDAY)
         ->assertJsonPath('data.recent_book_ids', [])
@@ -56,7 +59,7 @@ it('returns complete zero-filled bootstrap data in the application timezone', fu
         ->assertJsonCount(14, 'data.activity')
         ->assertJsonStructure([
             'data' => [
-                'user' => ['id', 'name', 'email'],
+                'user' => ['id', 'name', 'email', 'avatar_url'],
                 'today',
                 'yesterday',
                 'books' => ['*' => ['id', 'name', 'chapters', 'testament']],

--- a/tests/Feature/Api/V1/MobileTokenAuthenticationTest.php
+++ b/tests/Feature/Api/V1/MobileTokenAuthenticationTest.php
@@ -8,6 +8,7 @@ it('issues a non-expiring mobile bearer token for valid normalized credentials',
     $user = User::factory()->create([
         'email' => 'reader@example.com',
         'password' => Hash::make('ValidPass123!'),
+        'avatar_url' => null,
     ]);
 
     $response = $this->postJson('/api/v1/auth/token', [
@@ -22,11 +23,12 @@ it('issues a non-expiring mobile bearer token for valid normalized credentials',
         ->assertJsonPath('data.user.id', $user->id)
         ->assertJsonPath('data.user.name', $user->name)
         ->assertJsonPath('data.user.email', $user->email)
+        ->assertJsonPath('data.user.avatar_url', null)
         ->assertJsonStructure([
             'data' => [
                 'token',
                 'token_type',
-                'user' => ['id', 'name', 'email'],
+                'user' => ['id', 'name', 'email', 'avatar_url'],
             ],
         ]);
 


### PR DESCRIPTION
## Summary

- Expose `avatar_url` in mobile authentication and bootstrap API responses.
- Display stored profile photos in the account header and account sheet.
- Preserve initials or the account icon as a loading and failed-image fallback.
- Add API and mobile component coverage for profile photo rendering and fallback behavior.

## Testing

- Added and updated Laravel feature tests for avatar data in bootstrap and token responses.
- Added mobile tests covering image loading, account-sheet sizing, and failed-image fallback behavior.
- Not run (not requested).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added profile photo support to the mobile account menu.
  * Displays user avatars in the account header and profile details.
  * Shows initials or a default account icon when no photo is available.
  * Automatically falls back to initials if a profile photo fails to load.
  * Profile photo information is now included in mobile authentication and bootstrap responses.

* **Tests**
  * Added coverage for avatar display, sizing, loading, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->