### PR TITLE
[DEL-299] Pin EAS environments for release profiles

### DIFF
--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -6,6 +6,7 @@
     "preview": {
       "autoIncrement": true,
       "distribution": "internal",
+      "environment": "preview",
       "android": {
         "buildType": "apk"
       },
@@ -17,6 +18,7 @@
     "dogfood": {
       "autoIncrement": true,
       "distribution": "internal",
+      "environment": "production",
       "android": {
         "buildType": "apk"
       },

--- a/mobile/src/__tests__/app-config.test.js
+++ b/mobile/src/__tests__/app-config.test.js
@@ -151,6 +151,13 @@ describe('app configuration identities', () => {
     });
   });
 
+  it.each([
+    ['preview', 'preview'],
+    ['production', 'dogfood'],
+  ])('uses the %s EAS environment for the %s APK', (environment, profile) => {
+    expect(easConfig.build[profile].environment).toBe(environment);
+  });
+
   it.each(['development', 'preview', 'dogfood'])(
     'keeps %s valid while Google environment configuration is absent',
     (appVariant) => {


### PR DESCRIPTION
## Problem

EAS automatically assigns an environment when a build profile omits `environment`. The internal dogfood profile therefore inherited the Preview environment and could embed the staging Google OAuth client in a production-package APK.

## Implementation

- Map the `preview` profile explicitly to the EAS `preview` environment.
- Map the `dogfood` profile explicitly to the EAS `production` environment.
- Add focused configuration-contract coverage for both mappings.

## Verification

- `npm ci --cache /tmp/delight-del299-npm-cache --no-audit --no-fund`
- `npm run lint`
- `npm run typecheck`
- `npm test -- --watchman=false --runInBand` — 19 suites, 151 tests passed
- Preview `expo config --type public` resolution with the staging client
- Dogfood `expo config --type public` resolution with the production client
- `git diff --check`

## Release boundary

This PR only pins the environment selection. It does not run an EAS build, install an APK, accept the candidate, or distribute it. The project-scoped EAS production variable was configured separately under the approved external-configuration gate.

## Documentation consulted

- Expo EAS environment variable usage: https://docs.expo.dev/eas/environment-variables/usage/